### PR TITLE
Added github to the list of available importers in the custom_twist management command

### DIFF
--- a/mysite/customs/management/commands/customs_twist.py
+++ b/mysite/customs/management/commands/customs_twist.py
@@ -54,6 +54,7 @@ try:
     from bugimporters.roundup import RoundupBugImporter
     from bugimporters.bugzilla import BugzillaBugImporter
     from bugimporters.launchpad import LaunchpadBugImporter
+    from bugimporters.github import GitHubBugImporter
 
     tracker2importer.update({
         mysite.customs.models.BugzillaTrackerModel:
@@ -70,6 +71,9 @@ try:
         # Launchpad
         mysite.customs.models.LaunchpadTrackerModel:
             LaunchpadBugImporter,
+        # GitHub
+        mysite.customs.models.GitHubTrackerModel:
+            GitHubBugImporter,
     })
 
 except ImportError:


### PR DESCRIPTION
Also added logging info message for failed bugimporters import. This helps inform the user/developer that the imports failed in the case where the bugimporters library is installed and expected to be imported successfully.
