### PR TITLE
Enable git serving over HTTP

### DIFF
--- a/mysite/deployment_settings.py
+++ b/mysite/deployment_settings.py
@@ -45,7 +45,7 @@ CACHE_BACKEND = "memcached://linode.openhatch.org:11211/?timeout=1"
 
 GOOGLE_ANALYTICS_CODE='UA-15096810-1'
 
-GIT_REPO_URL_PREFIX = 'git://openhatch.org/git/'
+GIT_REPO_URL_PREFIX = 'https://openhatch.org/git-mission-data/git/'
 SESSION_COOKIE_DOMAIN='.openhatch.org' # Share cookies with subdomain (necessary for Vanilla)
 
 RECOMMEND_BUGS=False


### PR DESCRIPTION
This, combined with changes to Apache on linode.openhatch.org,
let people do git clones over HTTP. This is important because
sometimes people try to use the git training mission from
within restrictive firewalls.

Closes: http://openhatch.org/bugs/issue653
