### PR TITLE
Fix saving a portfolio entry (fixes issue #748)

### DIFF
--- a/mysite/profile/views.py
+++ b/mysite/profile/views.py
@@ -722,7 +722,7 @@ def delete_portfolio_entry_do(request):
 
 @login_required
 def save_portfolio_entry_do(request):
-    pk = request.POST['portfolio_entry__pk']
+    pk = request.POST.get('portfolio_entry__pk', 'undefined')
 
     if pk == 'undefined':
         project, _ = Project.objects.get_or_create(name=request.POST['project_name'])


### PR DESCRIPTION
When creating a new project from `/+portfolio/editor/`, the code was trying to get the pk of the project by getting it from `request.POST['portfolio_entry__pk']`. However for new projects there is no such element, so a MultiValueDictKeyError exception was launched, and since it was not catched it resulted in a 500 error.

My change uses the `.get` function of the `request.POST` object to retrieve that value, and gives it the value of `undefined` if it's not present. The next line already checks `if pk == 'undefined':`, so now there is no more exception being triggered, and the new project can be created.

This fixes https://openhatch.org/bugs/issue748
