### PR TITLE
Use memcached for sessions on deployment

### DIFF
--- a/mysite/deployment_settings.py
+++ b/mysite/deployment_settings.py
@@ -52,6 +52,9 @@ URL_PREFIX='https://openhatch.org'
 
 RECOMMEND_BUGS=False
 
+### Sessions in database, but cached in memcached if available
+SESSION_ENGINE="django.contrib.sessions.backends.cached_db"
+
 ### Set the logging level to just WARNING or above
 import logging
 logger = logging.getLogger('')


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/1.3/topics/http/sessions/

This should improve performance marginally, but moreover it's just healthy for the database, I figure. It also seems entirely safe.
