### PR TITLE
Fix XSS in map rendering page

### DIFF
--- a/mysite/static/js/profile/map-v2.js
+++ b/mysite/static/js/profile/map-v2.js
@@ -3,25 +3,27 @@ function drawAllPeopleDivsAtOnce(list_of_people_data) {
     var $text = $("<div>Drawing people...</div>");
     var i;
     var f;
-    var div;
-    var a;
-    var span;
+    var $div;
+    var $a;
+    var $span;
+    var text;
     var $results = $('<div id="results"></div>');
 
     $("#results").replaceWith($text);
 
 
     for (i = 0; i < list_of_people_data.length && i < MAX_TO_DISPLAY; i++) {
-	f = list_of_people_data[i];
-        div = $("<div />");
-        a = $("<a class='person' href='http://openhatch.org/people/"+f.attributes.all_data.extra_person_info.username+"/'>" + f.attributes.name + "</a>");
-        div.append(a);
-        span = $("<span class='geocode'>, " + f.attributes.location + "</span>");
-        div.append(span);
-        $results.append(div);
+        f = list_of_people_data[i];
+        href = "/people/" + f.attributes.all_data.extra_person_info.username;
+        $a = $("<a></a>", {class: 'person', href: href}).text(f.attributes.name);
+        $span = $("<span></span>", {class: 'geocode'}).text(f.attributes.location);
+        $div = $("<div></div>").append($a).append($span);
+        $results.append($div);
     }
     if (list_of_people_data.length >= MAX_TO_DISPLAY) {
-	$results.append($("<div>and " + (list_of_people_data.length - MAX_TO_DISPLAY) + " more; zoom the map to see them, or search for them specifically.</div>"));
+        text = "and " + (list_of_people_data.length - MAX_TO_DISPLAY) + " more; zoom the map to see them, or search for them specifically.";
+        $div = $("<div></div>").text(text);
+        $results.append($div);
     }
 
     $text.replaceWith($results);


### PR DESCRIPTION
If you had a person whose name was a carefully crafted HTML tag, then
the link to the person could include the HTML. This was due to the reckless
use of string concatenation to build HTML from within JavaScript, which is
always wrong.

This fix uses jQuery to build the elements.

It also moves the various variables to only be in-scope within the loops
they are relevant to.

To test it, log into your profile and set your name to be the string:

""><script>alert("3")</script>

You can do that at e.g. http://127.0.0.1:8000/account/settings/edit_name
