### PR TITLE
Adding trivial web API for listing bug importers

### DIFF
--- a/mysite/customs/api.py
+++ b/mysite/customs/api.py
@@ -1,0 +1,20 @@
+import mysite.customs.models
+import tastypie.resources
+import tastypie.authorization
+
+
+class TrackerModelResource(tastypie.resources.ModelResource):
+    # This is a trivial resource that just lets each BugImporter
+    # subclass export its data out to the web.
+    class Meta:
+        fields = [] # Let this be handled by dehydrate()
+        queryset = (mysite.customs.models.TrackerModel.objects.
+                    select_subclasses().all())
+        list_allowed_methods = ['get']
+        detail_allowed_methods = ['get']
+        resource_name = 'tracker_model'
+        authorization = tastypie.authorization.DjangoAuthorization()
+
+    def dehydrate(self, bundle):
+        '''Actually do the work of creating the dict here.'''
+        return bundle.obj.as_dict()

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -39,6 +39,7 @@ from voting.views import vote_on_object
 
 import mysite.account.views
 import mysite.profile.views
+import mysite.customs.api
 import mysite.profile.api
 import mysite.missions.svn.views
 import mysite.missions.setup.views
@@ -60,6 +61,9 @@ urlpatterns = patterns('',
 
         (r'^\+api/v1/profile/',
          include(mysite.profile.api.PortfolioEntryResource().urls)),
+
+        (r'^\+api/v1/customs/',
+         include(mysite.customs.api.TrackerModelResource().urls)),
 
         (r'^\+test_weekly_email_re_projects/', 'mysite.base.views.test_weekly_email_re_projects'),
 


### PR DESCRIPTION
This is the beginning of it being easier to test oh-bugimporters without having a shell.
