### PR TITLE
Patch for Issue 754 - Bug in Training mission : using diff and and patch Edit 

### DIFF
--- a/mysite/missions/diffpatch/controllers.py
+++ b/mysite/missions/diffpatch/controllers.py
@@ -69,8 +69,8 @@ class SingleFilePatch(object):
         # Maybe the problem is that the user accidentally removed
         # line-ending whitespace from the patch file. We detect that
         # by seeing if \n\n appears in the patch file.
-        if '\n\n' in patchdata:
-            raise IncorrectPatch, 'You seem to have removed the space (" ") characters at the end of some lines. Those are essential to the patch format'
+        if '\n\n' in patchdata or '\r\n\r\n' in patchdata:
+            raise IncorrectPatch, 'You seem to have removed the space (" ") characters at the end of some lines. Those are essential to the patch format. If you are a Windows user, check the hints on how to copy and paste from the terminal.'
 
         # Otherwise, we give a generic error message.
         raise IncorrectPatch, 'The file resulting from patching does not have the correct contents.'

--- a/mysite/missions/templates/missions/diffpatch/single_file_diff.html
+++ b/mysite/missions/templates/missions/diffpatch/single_file_diff.html
@@ -126,6 +126,11 @@
 	diff -u original nutty-pancake.txt
       </pre>
       <p>Then select that text with your mouse and use your terminal program's copy-paste functionality to copy it to the clipboard. Paste it into the form above.  Then, submit!</p>
+      <p>If you are a Windows user, redirect the output of your diff to a new file with this command:</p>
+      <pre>
+      	diff -u original new > output.txt
+      </pre>
+      <p>And then, copy and paste from that file. This will avoid stripping of white spaces, which usually happens when copying from the terminal.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Training mission was failing with windows generated diff files because of stripped white spaces
- Solved by putting in an exception for the scenario and adding hints for Windows users to redirect output to an external file
