### PR TITLE
removed duplicate word: 'your your' -> 'your'

### DIFF
--- a/mysite/profile/templates/profile/main.html
+++ b/mysite/profile/templates/profile/main.html
@@ -74,7 +74,7 @@
                             </strong>
                             <span>
                                 If you've contributed to open source already, say so on our project editor!
-                                We want you to share your your bug reports, translations, patches, community management, and code commits.
+                                We want you to share your bug reports, translations, patches, community management, and code commits.
                             </span>
                         </div>
                     </a>


### PR DESCRIPTION
Removed the double "your" that was previously present in the "Add Your Contributions" section that was shown to new users on their profile pages. 

Previous: "We want you to share your your bug reports..."
Revised: "We want you to share your bug reports..."
