### PR TITLE
clarified git training mission instructions regarding literals

### DIFF
--- a/mysite/missions/templates/missions/git/about_git.html
+++ b/mysite/missions/templates/missions/git/about_git.html
@@ -48,11 +48,11 @@
 During this training mission, you'll be making and sharing changes, so you'll have to configure
 git.</p>
 
-<p>First, tell git your name. (Replace 'First Last' with your name, surrounded by quotes.)</p>
+<p>First, tell git your name. (Replace 'First Last' with your name, surrounded by quotes. Note that user.name must be left in the command as shown below.)</p>
 
 <blockquote><tt>git config --global user.name 'First Last'</tt></blockquote>
 
-<p>Now, tell git your email address. (Replace 'name@domain.com' with your email address, surrounded by quotes.)</p>
+<p>Now, tell git your email address. (Replace 'name@domain.com' with your email address, surrounded by quotes. Note that user.email must be left in the command as shown below.)</p>
 
 <blockquote><tt>git config --global user.email 'name@domain.com'</tt></blockquote>
 


### PR DESCRIPTION
clarified git instructions by adding "Note that [literal] must be left in the command as shown below"
