### PR TITLE
Fix #741: Narrow .portfolio_entry > .submodule

### DIFF
--- a/mysite/static/css/profile/portfolio.css
+++ b/mysite/static/css/profile/portfolio.css
@@ -50,9 +50,9 @@ body#profile .portfolio_entry > .actions a,
     body#profile .portfolio_entry > .actions span { background-position: 5px; background-repeat: no-repeat; float: left; padding: 10%; padding-left: 35%; width: 55%; }
 body#profile .portfolio_entry > .actions a:hover { background-color: #e9e9e9; }
 body#profile .portfolio_entry > .actions li.save_and_publish_button *,
-body#profile .portfolio_entry > .submodule { clear: both; float: none; margin-bottom: 0;  }
+body#profile .portfolio_entry > .submodule { margin-right: 0; margin-bottom: 0;  }
 body#profile.view_mode .portfolio_entry > .submodule { border-width: 2px; margin-left: 10px; }
-body#profile #portfolio.editor .portfolio_entry > .submodule { margin-bottom: 0; width: 807px; }
+body#profile #portfolio.editor .portfolio_entry > .submodule { margin-bottom: 0; width: 770px; }
 body#profile .portfolio_entry .project-stuff { padding: 0 10px; float: left; width: 250px; }
 body#profile .portfolio_entry .personal-stuff { border-left: 1px solid #eee; padding: 10px 20px; margin-left: 280px; }
 body#profile .portfolio_entry .project_icon { float: left; height: 64px; margin-right: 10px; width: 64px; background-position: center; background-repeat: no-repeat; }


### PR DESCRIPTION
Before this fix, the interior of the div.module-body.contains-submodules
is 920px wide, but, including margins and borders, the .submodule is
888px wide, and the ul.action is 89px wide which is why the ul doesn't
properly float-left alongside the preceding clearfix div. Narrowing the
submodule div mitigates the issue on sufficiently wide viewports.

See https://openhatch.org/bugs/issue741 for test-setup instructions + before-and-after screenshots.
