### PR TITLE
Fixed 874 'Add/edit projects' should be visually in the same line as 'Projects'

### DIFF
--- a/mysite/profile/templates/profile/main.html
+++ b/mysite/profile/templates/profile/main.html
@@ -29,12 +29,16 @@
 {% block main %}
 <div id='portfolio' class='module project-display viewer'>
     <div class='module-head'>
+        <ul>
+            <li>
+                {% if editable %}
+                    <a class='add-edit-projects' href=
+                    '{% url mysite.profile.views.portfolio_editor %}'>Add/edit &raquo;
+                    </a>
+                {% endif %}
+            </li>
+        </ul>
         <h3>Projects</h3>
-            {% if editable %}
-                <a class='add-edit-projects' href=
-                '{% url mysite.profile.views.portfolio_editor %}'>Add/edit &raquo;
-                </a>
-            {% endif %}
     </div>
         <div class='module-body'>
         {% with person.get_published_portfolio_entries as portfolio_entries %} 


### PR DESCRIPTION
https://openhatch.org/bugs/issue874 This change is in the html formatting of the user profile page. On the right-hand side of the user profile, when you're logged in, you should see the "Add/Edit" url link. This change has been tested and the new HTML changes work. Feel free to code review. Thanks.
