### PR TITLE
Fixed 801 Users can edit name in their profile pg

### DIFF
--- a/mysite/account/forms.py
+++ b/mysite/account/forms.py
@@ -121,7 +121,7 @@ class EditLocationForm(django.forms.ModelForm):
 class EditNameForm(django.forms.ModelForm):
     class Meta:
         model = User
-        fields = ('first_name', 'last_name')
+        fields = ('first_name', 'last_name', 'username')
 
 class EditPhotoForm(django.forms.ModelForm):
     class Meta:

--- a/mysite/profile/templates/profile/base_profile.html
+++ b/mysite/profile/templates/profile/base_profile.html
@@ -38,13 +38,14 @@
     <div id='nameplate'>
             {% if person.user.first_name or person.user.last_name %}
             <h1 class='name'>
-                <a href='/people/{{ person.user.username }}'>
                     {{ person.user.first_name }}
                     {{ person.user.last_name }}
                     <span class='username' style="font-size: .7em;">
                         ({{ person.user.username }})
+                        {% if editable %}
+                            (<a href='{% url account.views.edit_name %}'>edit name</a>)
+                        {% endif %}
                     </span>
-                </a>
             </h1>
             {% else %}
             <h1 class='name'>

--- a/mysite/static/css/profile/base.css
+++ b/mysite/static/css/profile/base.css
@@ -11,6 +11,7 @@ body#profile #nameplate { float: left; width: 940px; margin-top: 20px; padding: 
 		body#profile #nameplate li a { font-size: 13pt; text-decoration: none; color: #999; }
 			body#profile #nameplate li a:hover { color: #666; text-decoration: underline; }
 	body#profile #nameplate .name { float: left; }
+	body#profile #nameplate h1 a { color: #ff6d3d; }
 	body#profile #nameplate .edit { float: left; width: 20px; margin-left: 5px; }
 	body#profile #nameplate .name-edit-link { float: left; padding: 10px 0; margin-right: 10px; }
 	body#profile #nameplate input[type='text'] { width: 160px; float: left; }


### PR DESCRIPTION
https://openhatch.org/bugs/issue801  Tested locally, it works. I made the UI as similar as possible to the "edit location" url link at the top left corner of the user's profile page.  See below screenshot of the new upper left corner of the user profile page: 

![801_solution](https://f.cloud.github.com/assets/954858/979672/5a4b75f0-0721-11e3-8172-b915341a037a.jpg)

In addition, I made the design decision to remove the `<a href='/people/{{ person.user.username }}'>` in base_profile.html, because this url link redirects users to the same current profile page and also having that link plus the `href='{% url account.views.edit_name %}` link is confusing for users who want to only click on the "edit name" link.

Do feel free to code review, @paulproteus @aldeka. Your feedback is always welcome. 
