### PR TITLE
Adding "that" to headline for clarity

### DIFF
--- a/mysite/base/templates/base/donate.html
+++ b/mysite/base/templates/base/donate.html
@@ -33,7 +33,7 @@
             <div class="col-sm-10">
                 <h2>
                     We are raising money to make Open Source Comes to Campus the most welcoming,
-                    diversity-increasing way new contributors join open source.
+                    diversity-increasing way that new contributors join open source.
                     <strong>You can help!</strong>
                 </h2>
             </div>


### PR DESCRIPTION
I found myself getting slightly lost while reading "the most welcoming, diversity-increasing way new contributors join open source", so I am proposing adding "that" to it for clarity.
