### PR TITLE
Strip tags before displaying project name

### DIFF
--- a/mysite/project/templates/project/project_list_item.html
+++ b/mysite/project/templates/project/project_list_item.html
@@ -23,7 +23,7 @@
             {% endif %}
             >
             <a href='{{ project.get_url }}'>
-                {{ project.display_name|break_long_words|safe }} 
+                {{ project.display_name|break_long_words|striptags|safe }}
             </a>
             <div class='summary'>
                 {% if project.get_bug_count %}


### PR DESCRIPTION
A project name such as '""><script>alert("asd")</script>' was causing
problems as described in http://openhatch.org/bugs/issue875

Use the Django 'striptags' filter to remove the tag at the end (standard
escaping does not seem to catch this for some reason, even after
specifying the 'escape' filter.)

Resulting fix still leaves a mangled project name, like '"">' or such,
but otherwise leaves the list of projects alone. I'm not totally
satisfied with this fix, and think we should have a similar one in the
submission form so project names like this don't get into the database
to begin with.

Signed-off-by: Mandar Gokhale mandar.mmg@gmail.com
