### PR TITLE
Update name of heroku free postgres add on

### DIFF
--- a/docs/advanced/heroku.rst
+++ b/docs/advanced/heroku.rst
@@ -122,7 +122,7 @@ create a database for it to use.
 
 To do that, run this command::
 
-  heroku addons:add --app better-frobulator shared-database
+  heroku addons:add --app better-frobulator heroku-postgresql:dev
 
 (Replace "better-frobulator" with the name of your Heroku app.) This will
 add a free-of-cost Postgres database to your app.


### PR DESCRIPTION
The mentioned 'shared-database' addon is currently not available in heroku and is replaced by 'heroku-postgresql:dev'. Check https://postgres.heroku.com/blog/past/2012/4/26/heroku_postgres_development_plan/
