### PR TITLE
Fixed #739 Made minor CSS fixes to /guide/

### DIFF
--- a/mysite/base/templates/base/guide.html
+++ b/mysite/base/templates/base/guide.html
@@ -70,7 +70,7 @@ document.documentElement.className = 'javascript_is_enabled';
 	<ul>
 	  <li><hr></li>
 	  <li>
-	    <a href="/contact/">
+	    <a class="contact_us" href="/contact/">
 	      Want to chat? Visit our 'Contact us' page!
 	    </a>
 	  </li>

--- a/mysite/static/less/base/base.less
+++ b/mysite/static/less/base/base.less
@@ -359,13 +359,18 @@ dd { margin-top: .5em; margin-left: 1.2em; }
 
 body ul.raquo_bullets {
     margin-left: 0; 
-    padding-left: .6em; 
+    padding-left: 1.1em; 
     text-indent: -1em; 
     list-style: none; 
     li { margin-bottom: .4em; 
         &:last-child { margin-bottom: 0; }
         &:before { color: #999; font-family: Georgia; margin-right: 2px; font-weight: bold; content: "\00BB \0020"; }
     }
+}
+
+.contact_us {
+    display: inline-block;
+    text-align: center;
 }
 
 /* CSSTODO */


### PR DESCRIPTION
Trying to resolve https://openhatch.org/bugs/issue739. 
Let me know how I can improve this pull request (PR). I mostly followed pythonian4000's suggestions in comments of the issue tracker. 

Please note that the below BEFORE vs. AFTER screenshots are local instances of oh-mainline running from localhost:800 on MacOX. 

BEFORE: 
![openhatch-before](https://f.cloud.github.com/assets/954858/1749789/96fc1ffa-653f-11e3-93c3-b4a17eb236c5.png)

AFTER: I centered the contact us link in left sidebar. The bullet points fit inside the gray box.
![openhatch-issue 739](https://f.cloud.github.com/assets/954858/1749787/79715ab8-653f-11e3-9303-9528d3d83b07.png)
