### PR TITLE
Fixed #908 -- Enable account notification for inviting friend to OH.

### DIFF
--- a/mysite/account/views.py
+++ b/mysite/account/views.py
@@ -389,10 +389,17 @@ def invite_someone(request, form=None, success_message=''):
     remaining_invites = InvitationKey.objects.remaining_invitations_for_user(
         request.user)
 
+    if request.GET.get('invited', None):
+        account_notification = "Email has been sent."
+    else:
+        account_notification = ""
+
     return (request, 'account/invite_someone.html', {
             'success_message': success_message,
             'invite_someone_form': invite_someone_form,
-            'remaining_invites': remaining_invites})
+            'remaining_invites': remaining_invites,
+            'account_notification': account_notification
+            })
 
 
 def proxyconnect_sso(request):


### PR DESCRIPTION
Resolves https://openhatch.org/bugs/issue908. Feel free to code review and make suggestions for improvement. 

New notification message after the Welcome to OH email has been sent to a friend (or enemy):

![openhatch-issue 908-invite-somone](https://f.cloud.github.com/assets/954858/1749991/1f1b9774-6560-11e3-8ac1-21f1ab567aa3.png)
