### PR TITLE
'heads up' about vendor dir

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -84,6 +84,11 @@ Step 4: Clone the repository from GitHub to your local computer::
 If your commands are executed successfully, you may continue to the next
 step.
 
+**Note:** For most Django projects, you would need to install the dependencies 
+at this point (using `pip install -r requirements.txt`), but for the Openhatch 
+project, these packages have been bundled for your convenience in the `vendor` 
+directory, so they don't need to be installed separately.
+
 Set up the database
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
provide an explanation for why they don't need to run 'pip install -r requirements' as they would have to do with just about any other Django project.
