### PR TITLE
Use TransactionTestCase, not TestCase

### DIFF
--- a/mysite/base/tests.py
+++ b/mysite/base/tests.py
@@ -70,7 +70,7 @@ mock_get = mock.Mock()
 mock_get.return_value = None
 
 
-class TwillTests(django.test.TestCase):
+class TwillTests(django.test.TransactionTestCase):
 
     @staticmethod
     def _twill_setup():


### PR DESCRIPTION
This fixes about 30 of the MySQL-related test failures.
