### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,11 @@ Welcome to OpenHatch's documentation
 
 You've reached the documentation for `OpenHatch <http://openhatch.org/>`_.  
 
-Trying to get your bearings?  Take a look at the :doc:`getting_started/project_overview` or :doc:`community/contact` us to ask questions.
+Trying to get your bearings?  Take a look at the :doc:`getting_started/project_overview` or :doc:`community/contact` to ask questions.
 
 We've also got a `wiki <https://openhatch.org/wiki/Main_Page>`_ with a lot of informal documentation and other useful things on it.
 
-Confused or dismayed by our documentation?  Please let us know so we can improve it!  Make an issue on our `issue tracker <http://openhatch.org/bugs/>`_ or :doc:`community/contact` us via email or IRC to chat with us about it.
+Confused or dismayed by our documentation?  Please let us know so we can improve it!  Make an issue on our `issue tracker <http://openhatch.org/bugs/>`_ or :doc:`community/contact` via email or IRC to chat with us about it.
 
 
 Content


### PR DESCRIPTION
Bug: Documentation had two instances of having duplicate words in two different places.

Proposed fix: removed the word "us" after 'community/contact'

Bug report: http://openhatch.org/bugs/issue914
