### PR TITLE
Fix "get help" to go to Contact instead of Events

### DIFF
--- a/mysite/base/templates/base/landing.html
+++ b/mysite/base/templates/base/landing.html
@@ -59,8 +59,8 @@ document.documentElement.className = 'javascript_is_enabled';
                     <p>browse tasks across open source <a href='{% url mysite.search.views.search_index %}'>by skill, difficulty, or project &raquo;</a></p>
                 </div>
                 <div class="submodule">
-                    <h4><a href="https://openhatch.org/wiki/Contact">Get help</a></h4>
-                    <p>ask us questions about <a href="https://openhatch.org/wiki/Contact">finding projects and contributing  &raquo;</a></p>
+                    <h4><a href="/wiki/Contact">Get help</a></h4>
+                    <p>ask us questions about <a href="/wiki/Contact">finding projects and contributing  &raquo;</a></p>
                 </div>
                 <div class="submodule">
                     <h4><a href='/guide/'>Add your project</a></h4>


### PR DESCRIPTION
A small link update to go with the new homepage!
