### PR TITLE
Update Continuous Integration doc to fix links and name change to Jenkins

### DIFF
--- a/docs/getting_started/handling_contributions.rst
+++ b/docs/getting_started/handling_contributions.rst
@@ -121,7 +121,7 @@ person to do this, but it's good to ask someone else so they get practice!
 
 Things to know:
 
-    * If you push to origin/master, Hudson will test it.
+    * If you push to origin/master, Jenkins will test it.
     * Once you're happy, you can run the deploy script, but note that will push
       the current HEAD to origin/master. ::
 
@@ -131,8 +131,8 @@ Things to know:
 
     * When you deploy, check a page or two to make sure things are okay.
 
-For more details on how we use Hudson and how to force a Hudson build, see
-`Continuous integration with Hudson`_.
+For more details on how we use Jenkins and how to force a Jenkins build, see
+`Continuous integration with Jenkins and Travis CI`_.
 
 .. _Login team: https://openhatch.org/wiki/Login_team
-.. _Continuous integration with Hudson: ../internals/continuous_integration.html
+.. _Continuous integration with Jenkins and Travis CI: ../internals/continuous_integration.html

--- a/docs/internals/continuous_integration.rst
+++ b/docs/internals/continuous_integration.rst
@@ -1,6 +1,6 @@
-===================================
-Continuous integration with Jenkins
-===================================
+=================================================
+Continuous Integration with Jenkins and Travis CI
+=================================================
 
 
 Overview
@@ -11,29 +11,30 @@ code to the website, all tests pass.
 
 Jenkins is a "continuous integration" tool (read `more on Wikipedia`_). It wakes
 up once an hour, checks the git repository for new commits, and runs the test
-suite.
-
+suite. For additional information about Jenkins, read `more on Jenkins`_.
 
 .. _more on Wikipedia: https://en.wikipedia.org/wiki/Continuous_integration
-
-
-For additional information about Jenkins, read `more on Jenkins`_.
-
-
 .. _more on Jenkins: https://jenkins-ci.org
+
+Travis CI is a hosted, distributed "continuous integration" system (read 
+`more on Wikipedia about Travis CI`_). For additional information about 
+Travis CI, read `more on Travis CI`_.
+
+.. _more on Wikipedia about Travis CI: https://en.wikipedia.org/wiki/Travis_CI
+.. _more on Travis CI: https://travis-ci.org
 
 
 Jenkins Dashboard for OpenHatch
 ===============================
 
 Status information about continuous integration projects can be found on 
-OpenHatch's Jenkins dashboard : http://vm3.openhatch.org:8080/
+OpenHatch's Jenkins dashboard : http://vm3.openhatch.org
 
 
 Configuration
 =============
 
-There are number of "projects" in Jenkins. Different ones run different suites of
+There are a number of "projects" in Jenkins. Different ones run different suites of
 tests in the OpenHatch codebase. They include or exclude different Django apps
 from the OpenHatch codebase.
 
@@ -61,12 +62,12 @@ For example,
 How to see the list of tests that failed or passed
 ==================================================
 
-* Go to http://vm3.openhatch.org:8080/
+* Go to http://vm3.openhatch.org
 * Choose a project (for example, `Test the search app`_)
 * Click on "Latest Test Result"
 
 
-.. _Test the search app: http://vm3.openhatch.org:8080/job/Test%20the%20%22search%22%20app/
+.. _Test the search app: http://vm3.openhatch.org/job/Test%20the%20%22search%22%20app/
 
 
 Permissions
@@ -81,8 +82,15 @@ a Jenkins project. That's a good thing.
 IRC
 ===
 
-It hangs out on #openhatch as openhatch_Hudson. Type !Hudsonhelp to find out the
+It hangs out on #openhatch as openhatch_hudson. Type !hudsonhelp to find out the
 bot's commands.
+
+
+Configuration for Travis CI
+===========================
+
+The `.travis.yml` file in the `oh-mainline` directory contains configuration
+information used by Travis CI.
 
 
 Future work


### PR DESCRIPTION
Issue 933 - Update internals documentation on Continuous Integration to reflect name change to Jenkins and fixed links to redirect to OpenHatch's Jenkins dashboard. Note: IRC bot still follows under the name openhatch_Hudson
