### PR TITLE
Fixed #932 -- Highlighted currently selected search filters in bold.

### DIFF
--- a/mysite/static/css/search/search.css
+++ b/mysite/static/css/search/search.css
@@ -27,6 +27,8 @@ body#search #filters { width: 75%; margin-right: 1%; margin-bottom: 10px; }
     body#search #facets { }
     body#search #facets ul { margin-left: 10px; }
     body#search #facets .facet-list { width: 20%;}
+    /* "bolder" is slightly more apparent than "bold". */
+    body#search #facets .facet-list ul li.active { font-weight: bolder; }
     body#search #facets ul li, #suggested_searches li, .facet_more_options li { list-style: circle; margin-left: 1em; color: #999; clear: left; }
     body#search #filters > .body > ul > li > ul { margin-top: .5em; }
     body#search #facets div.more_facet_options { list-style: none; margin-left: 2.5em; }


### PR DESCRIPTION
Highlighted filters have css style font-weight: bolder. Because "bolder" is slightly more apparent than "bold".

https://openhatch.org/bugs/issue932

![932_highlight_terms_bold](https://f.cloud.github.com/assets/954858/2118517/d0a2fbb2-910d-11e3-9806-dce69eb64b59.png)
