### PR TITLE
Fixed issue# 937 -- Non display of code tag content in li.raquo_bullets class

### DIFF
--- a/mysite/static/less/base/base.less
+++ b/mysite/static/less/base/base.less
@@ -372,6 +372,10 @@ body ul.raquo_bullets {
     li { margin-bottom: .4em; 
         &:last-child { margin-bottom: 0; }
         &:before { color: #999; font-family: Georgia; margin-right: 2px; font-weight: bold; content: "\00BB \0020"; }
+        code {
+            display: inline-table;
+            margin-left: 16px;
+        }
     }
 }
 


### PR DESCRIPTION
The issue # 937 has been fixed with the following setting in base.less 
https://openhatch.org/bugs/issue937

please review my changes.
