### PR TITLE
Fixes https://openhatch.org/bugs/issue938 - strange result from canceling an openid request

### DIFF
--- a/mysite/account/templates/authopenid/signin.html
+++ b/mysite/account/templates/authopenid/signin.html
@@ -17,20 +17,4 @@
 {% endcomment %}
 {% load i18n %}
 
-<form id="openid_form" name="openid_form" action="{% url "user_signin" %}" method="post">{% csrf_token %}
-    <input type="hidden" name="action" value="verify" />
-    <input type="hidden" name="next" value="{{ next }}" />
-        <fieldset>
-                <legend>{% trans "Sign In Using Your OpenID URL" %}</legend>
-                <div id="openid_choice">
-                <p>Please click your account provider:</p>
-                <div id="openid_btns"></div>
-        </div>
-            <div id="openid_input_area">
-                <label for="id_openid_url">{% trans "OpenId URL :" %}</label>{{ form1.openid_url }}
-                <input name="openid_submit" type="submit" value="{% trans "Sign in with OpenID" %}">
-            </div>
-                
-        </fieldset>
-</form> 
-
+{% include "account/login.html" %}


### PR DESCRIPTION
What I did: Updated the authopenid/signin.html template to reflect the account/login.html template so that django_authopenid displays the correct template when the user cancels the OpenID signup.

I considered several ways to do this:
1. Update the template referred to by the signin functions in django-authopenid/views.py so that the expected template is shown (this pull request)
2. Change the template used by the signin functions in django-authopenid/views.py to use 'account/login.html' (seemed a bit messy to be changing 3rd party files)
3. Copy the functions in django-authopenid for signin into mysite/account/views.py and tell them to use the 'account/login.html' template instead (seemed like too much redundancy)

I'm new to django and web dev in general, so there's probably another way to do this that I've missed. I think OH is an awesome idea though, and I really want to help out, so please suggest feedback and I will make the necessary changes :)
