### PR TITLE
Fix project template

### DIFF
--- a/mysite/project/templates/project/project.html
+++ b/mysite/project/templates/project/project.html
@@ -154,7 +154,6 @@ about how you can help {{ project.display_name }}
 
                                 {% endif %}
 
-                            </span>
                             </li>
                         {% endfor %}
 
@@ -175,7 +174,8 @@ about how you can help {{ project.display_name }}
                 What else do you want to talk about?
             </a>
         </strong>
-    </div><!-- /.module #requests -->
+    </div><!-- /#chatter -->
+</div><!-- /.module #requests -->
 
 {% endblock left %}
 


### PR DESCRIPTION
Currently, a page like http://openhatch.org/projects/OpenHatch looks like this: http://i.share.pho.to/afcb9543_o.png

I did a bit of digging and found it this layout issue is caused by a missing closing tag which messes up the DOM.

That pull request has two commits:
- The first one fixes the indentation to make it easier to find unbalanced tags (only leading whitespace is changed)
- The second actually fixes the issue by adding the missing `</div>` (it also removed an unneeded `</span>`).
