### PR TITLE
Try to serialize requests to update the blog feed

### DIFF
--- a/mysite/customs/feed.py
+++ b/mysite/customs/feed.py
@@ -22,6 +22,25 @@ from django.core.cache import cache
 
 OPENHATCH_BLOG_FEED_URL = 'http://openhatch.org/blog/feed/atom/'
 
+# How long we're willing to wait for our call to download the blog to complete.
+REQUEST_TIMEOUT = 3
+
+# After this number of seconds we consider the blog feed stale and we'll start
+# trying to refresh it.
+BLOG_ENTRY_CACHE_TIMEOUT = 30 * 60
+
+# The maximum number of seconds we'll keep blog entries in the cache. After
+# this length of time the cached blog entries will be deleted even if we can't
+# refresh the cache. This should be bigger than BLOG_ENTRY_CACHE_TIMEOUT and by
+# an amount that covers blips or small outages in the openhatch blog feed.
+STALENESS_TOLERANCE = 3 * 60 * 60
+
+# These are keys that we shove into our cache.
+KEY_PREFIX = 'blog_entries'
+DATA_KEYNAME = KEY_PREFIX + '-data'
+LOCK_KEYNAME = KEY_PREFIX + '-updatelock'
+FRESHNESS_KEYNAME = KEY_PREFIX + '-datafresh'
+
 
 def summary2html(html_string):
     soup = BeautifulSoup.BeautifulSoup(
@@ -31,7 +50,8 @@ def summary2html(html_string):
 
 def _blog_entries():
     try:
-        text = requests.get(OPENHATCH_BLOG_FEED_URL, timeout=3).text
+        text = requests.get(
+            OPENHATCH_BLOG_FEED_URL, timeout=REQUEST_TIMEOUT).text
         content = text.encode('utf-8', 'ignore')
     except requests.exceptions.Timeout:
         content = ''
@@ -43,11 +63,84 @@ def _blog_entries():
     return parsed['entries']
 
 
-def cached_blog_entries():
-    key_name = 'blog_entries'
-    entries = cache.get(key_name)
-    if entries is None:
-        entries = _blog_entries()
-        # cache it for 30 minutes
-        cache.set(key_name, entries, 30 * 60)
+class CacheLockInUse(Exception):
+    pass
+
+
+class CacheLock(object):
+    """A super lame excuse for a lock.
+
+    Provides a context manager for attempting to serialize access to some
+    protected resource via operations in a cache. The gist is that if a key
+    exists in the cache then that "lock" is taken. To acquire the lock then we
+    see if no one else already holds it, and if so we set the key. There's an
+    obvious and probable race condition here where two people do this at the
+    same time and they both set the lock at the same time. The behavior here is
+    that two people do the work we're trying to serialize. Not the end of the
+    world.
+    """
+    def __init__(self, LOCK_KEYNAME):
+        self.lock_keyname = LOCK_KEYNAME
+
+    def acquire_lock(self):
+        cache.set(self.lock_keyname, 'me', REQUEST_TIMEOUT + 1)
+
+    def release_lock(self):
+        cache.delete(self.lock_keyname)
+
+    def __enter__(self):
+        if cache.get(self.lock_keyname):
+            raise CacheLockInUse()
+        self.acquire_lock()
+
+    def __exit__(self, type, value, traceback):
+        self.release_lock()
+
+
+def cached_blog_entries(
+        blog_fetcher=_blog_entries,
+        key_prefix=KEY_PREFIX):
+    """Return a cached copy of blog entries that we've fetched.
+
+    The parameters to this function are used for testing. The defaults are
+    correct for actual usage.
+
+    We use three cache keys to control whether or not we need to:
+
+        - refresh our data
+        - whether or not someone is already refreshing the copy
+        - the actual cached content.
+
+    Nominally we come in here the cache is fresh and the data is present. We do
+    two cache reads. First to check that the freshness key hasn't expired.
+    Since it hasn't we then issue a second cache read to get the cached blog
+    entries.
+
+    The second case we're likely to hit is that the freshness cache key returns
+    None, which we use to mean expired. In that case we need to attempt to grab
+    the updater lock, update the cache, and then return the freshly cached
+    entries.
+
+    Within that second case its possible that the lock will already be taken.
+    In that case we simply return the cached data despite it being older than
+    we really want.
+    """
+    blog_lock = CacheLock(key_prefix + LOCK_KEYNAME)
+
+    # nominal case where the data is fresh and in the cache
+    if cache.get(key_prefix + FRESHNESS_KEYNAME):
+        entries = cache.get(key_prefix + DATA_KEYNAME)
+        if entries:
+            return entries
+
+    # Data is stale, we'll try to update or just return the stale stuff
+    try:
+        with blog_lock:
+            entries = blog_fetcher()
+    except CacheLockInUse:
+        return cache.get(key_prefix + DATA_KEYNAME)
+
+    # set_many not used because of varying timeout settings
+    cache.set(key_prefix + FRESHNESS_KEYNAME, 'yay', BLOG_ENTRY_CACHE_TIMEOUT)
+    cache.set(key_prefix + DATA_KEYNAME, entries, STALENESS_TOLERANCE)
     return entries

--- a/mysite/customs/tests.py
+++ b/mysite/customs/tests.py
@@ -134,6 +134,51 @@ class BlogCrawl(django.test.TestCase):
                          u'Yo \xe9')
 
 
+class BlogCache(django.test.TestCase):
+    """Test caching of blog entries.
+
+    Because the cache is reused across tests (Effectively global) we fudge a
+    unique key prefix per test so that the key namespace is different for each
+    test method. This is pretty lame. But that's why those exist all over in
+    the tests.
+    """
+    def blog_fetcher_version_1(self):
+        return 'this-data-is-fake'
+
+    def blog_fetcher_version_2(self):
+        return 'this-data-is-also-fake'
+
+    def test_basics(self):
+        for i in range(4):
+            entries = mysite.customs.feed.cached_blog_entries(
+                self.blog_fetcher_version_1, key_prefix='a')
+            self.assertEqual(entries, self.blog_fetcher_version_1())
+
+    def test_with_lock_contention(self):
+        # Take the lock and then tell our code to go update the entries.
+        # It'll fail.
+
+        # Shove in data version 1
+        mysite.customs.feed.cached_blog_entries(
+            self.blog_fetcher_version_1, key_prefix='b')
+        # Delete the freshness key so that it looks like it expired.
+        mysite.customs.feed.cache.delete('bblog_entries-datafresh')
+
+        # Take the lock so that the code under test can't get it
+        blog_update_lock = mysite.customs.feed.CacheLock(
+            'b' + mysite.customs.feed.LOCK_KEYNAME)
+        with blog_update_lock:
+            entries = mysite.customs.feed.cached_blog_entries(
+                self.blog_fetcher_version_2, key_prefix='b')
+        # Verify that we still got stale data in return
+        self.assertEqual(entries, self.blog_fetcher_version_1())
+
+        # With the lock released, try to update again
+        entries = mysite.customs.feed.cached_blog_entries(
+            self.blog_fetcher_version_2, key_prefix='b')
+        # And ensure that we get data version 2 (Fake)
+        self.assertEqual(entries, self.blog_fetcher_version_2())
+
 @skipIf(mysite.base.depends.lxml.html is None, "To run these tests, you must install lxml. See ADVANCED_INSTALLATION.mkd for more.")
 class DataExport(django.test.TestCase):
 


### PR DESCRIPTION
Make a best effort to only allow one client/request to make the backend
HTTP request to the blog feed.

Addresses issue 928 (http://openhatch.org/bugs/issue928)
