### PR TITLE
Corrected profile test to properly check that the user has tags are assigned

### DIFF
--- a/mysite/profile/models.py
+++ b/mysite/profile/models.py
@@ -370,12 +370,6 @@ class Person(models.Model):
             ret[link.tag.tag_type.name].add(link.tag.text.lower())
         return ret
 
-    def get_tags_as_list(self):
-        ret = []
-        for link in self.link_person_tag_set.all():
-            ret.append(link)
-        return ret
-
     def get_tag_descriptions_for_keyword(self, keyword):
         keyword = keyword.lower()
         d = self.get_tags_as_dict()

--- a/mysite/profile/tests.py
+++ b/mysite/profile/tests.py
@@ -2619,7 +2619,7 @@ class PeopleMapSummariesAreCheap(TwillTests):
         # Link them to the Person
         for tag in Tag.objects.all():
             Link_Person_Tag.objects.create(person=self.paulproteus, tag=tag)
-        n = len(self.paulproteus.get_tags_as_list())
+        n = self.paulproteus.link_person_tag_set.all().count()
         self.assertEquals(3, n)
 
         # Give paulproteus some projects


### PR DESCRIPTION
Noticed that before we just had a counter to determine the amount of tags. I added a return tags as list which might prove useful later on, as well as, I have corrected the test to check the length of the tags assigned to the user.
