### PR TITLE
Fixed diffpatch hints

### DIFF
--- a/mysite/missions/templates/missions/diffpatch/recursive_diff.html
+++ b/mysite/missions/templates/missions/diffpatch/recursive_diff.html
@@ -97,9 +97,8 @@
 	<p>The "high" level is great if you are unfamiliar with the commands and tools you'd use.</p>
     </div>
     <div id="low">
-      <pre>man patch</pre>
-      <p>or
-	<a href="http://linux.die.net/man/1/patch">read the patch page online</a>.</p>
+      <p><a href="http://linux.die.net/man/1/diff">Read the man page for diff online</a>,</p>
+      <p>or, if you're on Linux or Mac, use the terminal command: <pre>man diff</pre></p>
     </div>
     <div id="medium">
       <p>In this mission, you have to do a few things. Tips:</p>

--- a/mysite/missions/templates/missions/diffpatch/recursive_patch.html
+++ b/mysite/missions/templates/missions/diffpatch/recursive_patch.html
@@ -89,18 +89,17 @@
 	<p>The "high" level is great if you are unfamiliar with the commands and tools you'd use.</p>
     </div>
     <div id="low">
-      <pre>man patch</pre>
-      <p>or
-	<a href="http://linux.die.net/man/1/patch">read the patch page online</a>.</p>
+      <p><a href="http://linux.die.net/man/1/patch">Read the man page for patch online</a>,</p>
+      <p>or, if you're on Linux or Mac, use the terminal command: <pre>man patch</pre></p>
     </div>
     <div id="medium">
       <p>Tips:</p>
 
-      <p>You can invoke <code>patch</code> on the downloaded file as follows:</p>
+      <p>You can invoke <tt>patch</tt> on the downloaded file as follows:</p>
 
-      <p><code>patch -p1 &lt; recipes.patch</code></p>
+      <p><pre>patch -p1 &lt; recipes.patch</pre></p>
 
-      <p>That should apply the patch file. Open up <code>recipes.patch</code> in a text editor and read the patch file "headers". Pay special attention to the directory paths. The <code>-p1</code> says to ignore up through the first "/" in the paths in the patch headers when trying to find files to patch.</p>
+      <p>That should apply the patch file. Open up <tt>recipes.patch</tt> in a text editor and read the patch file "headers". Pay special attention to the directory paths. The <tt>-p1</tt> says to ignore up through the first "/" in the paths in the patch headers when trying to find files to patch.</p>
     </div>
     <div id="high">
       <p>Open a command prompt, and type these commands in, one at a time. You need to copy them exactly. Make sure to press enter between each one.</p>

--- a/mysite/missions/templates/missions/diffpatch/single_file_diff.html
+++ b/mysite/missions/templates/missions/diffpatch/single_file_diff.html
@@ -96,8 +96,8 @@
 	<p>The "high" level is great if you are unfamiliar with the commands and tools you'd use.</p>
     </div>
     <div id="low">
-    <a href="http://linux.die.net/man/1/patch">Read the man page online</a>,
-      <p>or if you are on Mac OSX or Linux, use the terminal command:<pre> man patch</pre></p>
+        <p><a href="http://linux.die.net/man/1/diff">Read the man page for diff online</a>,</p>
+        <p>or, if you're on Linux or Mac, use the terminal command: <pre>man diff</pre></p>
     </div>
     <div id="medium">
       <p>In this mission, you have to do a few things. Tips:</p>

--- a/mysite/missions/templates/missions/diffpatch/single_file_patch.html
+++ b/mysite/missions/templates/missions/diffpatch/single_file_patch.html
@@ -92,12 +92,15 @@
 	<p>The "high" level is great if you are unfamiliar with the commands and tools you'd use.</p>
     </div>
     <div id="low">
-      <pre>man patch</pre>
-      <p>or
-	<a href="http://linux.die.net/man/1/patch">read the man page online</a>.</p>
-    </div>
+      <p><a href="http://linux.die.net/man/1/patch">Read the man page for patch online</a>,</p>
+      <p>or, if you're on Linux or Mac, use the terminal command: <pre>man patch</pre></p>
+	</div>
     <div id="medium">
-	 <p>One way to accomplish this is by running a command like <pre>patch -p0 &lt; patch_file</pre> from the command-line, in the directory containing both <code>patch_file</code> and the original file (replace <code>"patch_file"</code> with the actual name of the file you downloaded). This command says "use the patch program to apply the diff in <code>patch_file</code> to a file in the current directory". You can read more about the <code>patch</code> program in its <a href="http://linux.die.net/man/1/patch">man page</a> (or type <code>man patch</code> at the command-line).</p>
+	 <p>One way to accomplish this is by running a command like</p>
+	 <tt>patch -p0 &lt; patch_file</tt> 
+	 <p>from the command-line, in the directory containing both <tt>patch_file</tt> and the original file (replace <tt>"patch_file"</tt> with the actual name of the file you downloaded).</p> 
+	 <p>This command says "use the patch program to apply the diff in <tt>patch_file</tt> to a file in the current directory".</p> 
+	 <p>You can read more about the <tt>patch</tt> program in its <a href="http://linux.die.net/man/1/patch">man page</a> or if you are on Mac or Linux, type: <pre>man patch</pre> at the command-line.</p>
     </div>
     <div id="high">
       <p>Open a command prompt, and type these commands in, one at a time. You need to copy them exactly. Make sure to press enter between each one.</p>


### PR DESCRIPTION
Fixed Issue 812: git bash doesn't include some tools needed for the diff-patch training mission
