### PR TITLE
Add info on override local settings in docs

### DIFF
--- a/docs/advanced/advanced_installation.rst
+++ b/docs/advanced/advanced_installation.rst
@@ -6,6 +6,15 @@ This file contains information on things that you don't have to do! If
 you're a completionist or really just like installing dependencies or
 reading the OpenHatch documentation, keep reading.
 
+Overriding local settings
+=================
+
+If you wish to override the default settings, you may create a
+separate file with individual settings you wish to change.
+There is a hook at the end of the in mysite/settings.py that allows
+contributors to override indiviual settings. To override settings,
+create a new file in the mysite directory and name it local_settings.py.
+You can place any settings you wish to override in this file.
 
 Automated testing
 =================


### PR DESCRIPTION
Add some brief information on overriding local settings in the
advanced installation that is missing from the documentation.
