### PR TITLE
Show sort order detail on /search popups

### DIFF
--- a/mysite/base/templates/more_facet_options.html
+++ b/mysite/base/templates/more_facet_options.html
@@ -22,7 +22,7 @@
                                         More {{ facet_name }}s &raquo;
                                     </a>
                                     <div style='display: none;' id='{{ facet_name }}s'>
-                                        <h2>Select a {{ facet_name }}</h2>
+                                        <h2>Select a {{ facet_name }} {{ facet.sorted_by }}</h2>
                                         <ul class='facet_more_options'>
                                             {% for option in facet.options %}
                                                 {% include 'facet_option.html' %}

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -74,7 +74,7 @@ Volunteer opportunities in free and open source software
                         }
                     {% endcomment %}
                     <div class="submodule facet-list">
-                        <h3>{{ facet.sidebar_heading }}</h3>
+                        <h3>{{ facet.sidebar_heading }} {{ facet.sorted_by }}</h3>
                         <ul>
                             {% if query %}
                                 {% for option in facet.options|slice:':4' %}

--- a/mysite/search/view_helpers.py
+++ b/mysite/search/view_helpers.py
@@ -284,31 +284,35 @@ class Query:
             # now"
             (u'language', {
                 u'name_in_GET': u"language",
-                u'sidebar_heading': u"Languages (# of bugs)",
+                u'sidebar_heading': u"Languages",
                 u'description_above_results': u"projects primarily coded in %s",
                 u'options': language_options,
                 u'the_any_option': self.get_facet_options(u'language', [u''])[0],
+                u'sorted_by': u'(# of bugs)',
             }),
             (u'project', {
                 u'name_in_GET': u'project',
-                u'sidebar_heading': u'Projects (# of bugs)',
+                u'sidebar_heading': u'Projects',
                 u'description_above_results': 'in the %s project',
                 u'options': project_options,
                 u'the_any_option': self.get_facet_options(u'project', [u''])[0],
+                u'sorted_by': u'(# of bugs)',
             }),
             (u'toughness', {
                 u'name_in_GET': u"toughness",
-                u'sidebar_heading': u"Toughness (# of bugs)",
+                u'sidebar_heading': u"Toughness",
                 u'description_above_results': u"where toughness = %s",
                 u'options': toughness_options,
                 u'the_any_option': self.get_facet_options(u'toughness', [u''])[0],
+                u'sorted_by': u'(# of bugs)',
             }),
             (u'contribution type', {
                 u'name_in_GET': u"contribution_type",
-                u'sidebar_heading': u"Just bugs labeled... (# of bugs)",
+                u'sidebar_heading': u"Just bugs labeled...",
                 u'description_above_results': u"which need %s",
                 u'options': contribution_type_options,
                 u'the_any_option': self.get_facet_options(u'contribution_type', [u''])[0],
+                u'sorted_by': u'(# of bugs)',
             })
         )
 


### PR DESCRIPTION
I've added a new facet field sorted_by for issue743. This will show sorting information /search page popups (where they currently show no details like '(# of bugs)')
