### PR TITLE
Fixed the "Using tar" low hints

### DIFF
--- a/mysite/missions/templates/missions/tar/creating.html
+++ b/mysite/missions/templates/missions/tar/creating.html
@@ -92,10 +92,10 @@
 	</div>
 	<div id="low">
 	  <ul class="raquo_bullets">
-	    <li>create a <code>myproject-0.1</code> directory</li>
-	    <li>download the files above and place them in the directory</li>
-	    <li>in the parent directory, create a gzipped tarball of the <code>myproject-0.1</code> directory</li>
-	    <li>upload your tarball</li>
+	    <li>Create a <tt>myproject-0.1</tt> directory</li>
+	    <li>Download the files above and place them in the directory</li>
+	    <li>In the parent directory, create a gzipped tarball of the <tt>myproject-0.1</tt> directory</li>
+	    <li>Upload your tarball</li>
 	  </ul>
 	</div>
 	<div id="high">

--- a/mysite/missions/templates/missions/tar/unpacking.html
+++ b/mysite/missions/templates/missions/tar/unpacking.html
@@ -82,9 +82,9 @@
 	</div>
 	<div id="low">
 	  <ul class="raquo_bullets">
-            <li>download the tarball</li>
-            <li>unpack it</li>
-            <li>find and upload the <code>{{ file_we_want }}</code> file</li>
+            <li>Download the tarball</li>
+            <li>Unpack it</li>
+            <li>Find and upload the <tt>{{ file_we_want }}</tt> file</li>
         </ul>
 	</div>
 	<div id="high">

--- a/mysite/static/css/missions/base.css
+++ b/mysite/static/css/missions/base.css
@@ -94,3 +94,7 @@ body#missions_index .submodule .status {
     text-align: center;
     width: 80%;
 }
+
+#low {
+    clear: both;
+}


### PR DESCRIPTION
Fixed: Issue 958 - In the "Using tar" mission, the first line of every low hint is way off to the right https://openhatch.org/bugs/issue958
