### PR TITLE
CSS fix for issue 956 comment msg4254. Settings page.

### DIFF
--- a/mysite/account/templates/account/settings.html
+++ b/mysite/account/templates/account/settings.html
@@ -38,7 +38,7 @@ Settings
         </ul>
     </div>
     <div class='module-body contains-submodules two-columns'>
-        <div class='submodule skinny'>
+        <div class='submodule skinny column two-column-left'>
             <div class='submodule-body'>
                 <ul>
                     <style>
@@ -58,7 +58,7 @@ Settings
                     </li>
                     <li id='link-widget'>
                     <a href='{% url account.views.widget %}'>
-                        Widgetize yourself 
+                        Widgetize yourself
                     </a>
                     </li>
                     <li id='link-invite_someone'>

--- a/mysite/account/templates/account/settings_tab.html
+++ b/mysite/account/templates/account/settings_tab.html
@@ -23,7 +23,7 @@
 {% comment %}
 NB: All forms in pages that descend from this have the same name.
 {% endcomment %}
-<div class='submodule fat'>
+<div class='submodule fat column two-column-right'>
     <div class='submodule-head'>
         <h3>{% block submodule_head %}{% endblock %}</h3>
     </div>

--- a/mysite/static/less/base/one_column.less
+++ b/mysite/static/less/base/one_column.less
@@ -3,31 +3,31 @@
 /* CSSTODO
    One day, we'll probably want to review this and clean it up. */
 
-body.one_column #main { float: none; 
+body.one_column #main { float: none;
     .submodule .head h3 { font-weight: normal; font-size: 11pt; }
     .submodule .body, #main .submodule .foot { padding: 3% 5%; float: left; }
 
     /* SKINNY SUBMODULE */
-    .submodule.skinny { width: 25%; margin-right: 20px; 
-        .submodule-head { width: 82.5%; 
+    .submodule.skinny { width: 25%; margin-right: 15px;
+        .submodule-head { width: 82.5%;
             h3 { width: 95%; }
         }
         .submodule-body { width: 90%; }
     }
 
     /* FAT SUBMODULE */
-    .submodule.fat { width: 67%; 
-        .submodule-head { width: 93.8%; 
+    .submodule.fat { width: 67%;
+        .submodule-head { width: 93.8%;
             h3 { width: 100%; }
         }
         .submodule-body { width: 90%; }
         .submodule-foot { width: 90%; }
     }
 
-    .equal-width { 
-        width: 45%; 
-        .submodule { 
-        width: 45%; 
+    .equal-width {
+        width: 45%;
+        .submodule {
+        width: 45%;
             submodule-head, .submodule-body, .submodule-foot { width: 90.5%; }
         }
     }


### PR DESCRIPTION
Fixed some CSS issues for [issue956](https://openhatch.org/bugs/issue956):
- Changed the skinny class to have a margin-right of 15px
- Added column and two-columns-\* to components in the settings.html and settings_tab.html files.

Before:
![openhatch_set_location](https://cloud.githubusercontent.com/assets/1918027/2739626/b17c92f0-c6b6-11e3-8534-87915aa897b6.png)

After:
![openhatch_settings_fix_align](https://cloud.githubusercontent.com/assets/1918027/2739638/f8ffbe2c-c6b6-11e3-8a27-5ba39effcd46.png)
