### PR TITLE
Fixed google issue URL from ATOM to CSV for issue871

### DIFF
--- a/mysite/customs/models.py
+++ b/mysite/customs/models.py
@@ -369,6 +369,9 @@ class GoogleTrackerModel(TrackerModel):
 
     all_trackers = models.Manager()
 
+    BUG_STATUS_OPEN = 2
+    BUG_STATUS_ALL = 1
+
     def __str__(self):
         return smart_str('%s' % (self.tracker_name))
 
@@ -379,11 +382,10 @@ class GoogleTrackerModel(TrackerModel):
             'last_polled__min']
         if lowest_last_polled is None:
             lowest_last_polled = datetime.datetime(1970, 1, 1)
-        query_data = {u'can': u'all',
-                      u'updated-min': unicode(lowest_last_polled.isoformat())}
-        query_url = google_query_url(self.google_name,
-                                     **query_data)
+
+        query_url = google_query_url(self.google_name, can=self.BUG_STATUS_ALL)
         out['get_older_bug_data'] = query_url
+
         return out
 
     def get_base_url(self):
@@ -391,13 +393,29 @@ class GoogleTrackerModel(TrackerModel):
 
 
 def google_query_url(project_name, **kwargs):
-    extra_data = {u'max-results': u'10000',
-                  u'can': u'open',
-                  }
+    extra_data = {
+        u'num': 1000,  # 1000 is the maximum we can fetch
+        u'can': GoogleTrackerModel.BUG_STATUS_OPEN,
+        u'colspec': ' '.join((
+            'ID',
+            'Status',
+            'Priority',
+            'Owner',
+            'Summary',
+            'Stars',
+            'Opened',
+            'Closed',
+            'Reporter',
+            'Cc',
+            'Difficulty',
+            'Modified',
+            'Type',
+        )),
+    }
     extra_data.update(kwargs)
-    base = 'https://code.google.com/feeds/issues/p/%s/issues/full' % (project_name,)
-    url = base + '?' + http.urlencode(extra_data)
-    return url
+
+    base = 'https://code.google.com/p/{project}/issues/csv'.format(project=project_name)
+    return '{url}?{params}'.format(url=base, params=http.urlencode(extra_data))
 
 
 class GoogleQueryModel(TrackerQueryModel):


### PR DESCRIPTION
This change will use google issue CSV files instead of ATOM feeds. Tests are included for this change. There is also a related pull request to the importer in oh-bugimporters that does the heavy lifting.
