### PR TITLE
Update link to windows git installation link

### DIFF
--- a/mysite/missions/templates/missions/windows-setup/install-git-bash.html
+++ b/mysite/missions/templates/missions/windows-setup/install-git-bash.html
@@ -32,7 +32,7 @@
     </ul>
 
     <p>To install it, go to the
-      <a href="http://code.google.com/p/msysgit/downloads/list?q=label:Featured">msysgit featured downloads list</a>
+      <a href="http://github.com/msysgit/msysgit/releases/">msysgit featured downloads list</a>
       and find the most recent "Full installer." At the time of writing, it is called "Git-1.7.8-preview20111206.exe". Click on that link, and click again to download the file.</p>
 
     <p>Find the file on your computer, and run it. You'll see a series of questions; <strong>we recommend accepting the defaults</strong>.</p>


### PR DESCRIPTION
The link previous link to install git led to a blank google code page. Now it
links to the latest release of msysgit.
