### PR TITLE
Issue 963 Modified test for Jira tracker and comments for GitHub tracker

### DIFF
--- a/mysite/customs/tests.py
+++ b/mysite/customs/tests.py
@@ -708,6 +708,10 @@ class GitHubTrackerEditingViews(TwillTests):
 
         self.assertEqual(1,
                          mysite.customs.models.GitHubTrackerModel.objects.all().select_subclasses().count())
+        # We test for 2 GitHubQueryModel.objects since we must create
+        # QueryModels (one for 'open' bugs, another for 'closed'
+        # bugs), since GitHub's v2 API doesn't let us list all bugs
+        # regardless of status.
         self.assertEqual(2,
                          mysite.customs.models.GitHubQueryModel.objects.all().count())
 
@@ -762,7 +766,7 @@ class JiraTrackerEditingViews(TwillTests):
 
         self.assertEqual(1,
                          mysite.customs.models.JiraTrackerModel.objects.all().select_subclasses().count())
-        self.assertEqual(2,
+        self.assertEqual(1,
                          mysite.customs.models.JiraQueryModel.objects.all().count())
 
 # Tests for importing bug data from YAML files, as emitted by oh-bugimporters


### PR DESCRIPTION
Please test this pull request with and without lxml installed. If lxml is not present, the `test_form_create_jira_tracker (mysite.customs.tests.JiraTrackerEditingViews)`will be skipped.

https://openhatch.org/bugs/issue963

I believe that the JiraTrackerForm save method only creates one JiraQueryModel, and the test should assert 1 instead of 2.
The GitHubTracker form save method creates two GitHubQueryModels since the GitHub v2 API does not allow open and closed issues to be queried simultaneously as one query, and this test reasonably asserts 2. 

Source from `oh-mainline/mysite/customs/forms.py` for your reviewing convenience.

```
class JiraTrackerForm(django.forms.ModelForm):

    class Meta:
        model = mysite.customs.models.JiraTrackerModel

    def save(self, *args, **kwargs):
        obj = super(JiraTrackerForm, self).save(*args, **kwargs)
        qm, _ = mysite.customs.models.JiraQueryModel.objects.get_or_create(
            tracker=obj)

        return obj
```

```
    def save(self, *args, **kwargs):
        # Call out to superclass
        obj = super(GitHubTrackerForm, self).save(*args, **kwargs)

        # Create two QueryModels (one for 'open' bugs, another for 'closed'
        # bugs), since GitHub's v2 API doesn't let us list all bugs
        # regardless of status.
        open_qm, _ = mysite.customs.models.GitHubQueryModel.objects.get_or_create(
            tracker=obj, state='')
        closed_qm, _ = mysite.customs.models.GitHubQueryModel.objects.get_or_create(
            tracker=obj, state='closed')

        # Return the "upstream" return value
        return obj
```
