### PR TITLE
Fixed broken 'Contact Us' link

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -2,7 +2,7 @@
 Getting Started
 =============================
 
-Confused?  `Contact us <http://openhatch.readthedocs.org/en/latest/contributor/contact.html>`_.
+Confused?  `Contact us <http://openhatch.readthedocs.org/en/latest/community/contact.html>`_.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
The very first link on this page is broken.

old: http://openhatch.readthedocs.org/en/latest/contributor/contact.html
new: http://openhatch.readthedocs.org/en/latest/community/contact.html

I have verified the that the new link is correct and working as intended.
