### PR TITLE
Keep certain handler code from executing if loading snapshot via raw

### DIFF
--- a/mysite/profile/models.py
+++ b/mysite/profile/models.py
@@ -550,8 +550,9 @@ def reject_when_query_is_only_whitespace(sender, instance, **kwargs):
         raise ValueError, "You tried to save a DataImportAttempt whose query was only whitespace, and we rejected it."
 
 
-def update_the_project_cached_contributor_count(sender, instance, **kwargs):
-    instance.project.update_cached_contributor_count_and_save()
+def update_the_project_cached_contributor_count(sender, instance, raw, **kwargs):
+    if not raw:
+        instance.project.update_cached_contributor_count_and_save()
 
 models.signals.pre_save.connect(
     reject_when_query_is_only_whitespace, sender=DataImportAttempt)
@@ -942,9 +943,10 @@ models.signals.post_save.connect(
 # change.
 
 
-def flush_map_json_cache(*args, **kwargs):
-    path = os.path.join(settings.WEB_ROOT, '+cacheable')
-    shutil.rmtree(path, ignore_errors=True)
+def flush_map_json_cache(raw, *args, **kwargs):
+    if not raw:
+        path = os.path.join(settings.WEB_ROOT, '+cacheable')
+        shutil.rmtree(path, ignore_errors=True)
 
 models.signals.post_save.connect(flush_map_json_cache, sender=PortfolioEntry)
 models.signals.post_save.connect(flush_map_json_cache, sender=Person)

--- a/mysite/search/models.py
+++ b/mysite/search/models.py
@@ -641,11 +641,12 @@ class WannaHelperNote(OpenHatchModel):
         return urljoin(reverse('mysite.project.views.project', args=[self.project.name]), "#person_summary_%d" % self.person.pk)
 
 
-def post_bug_save_delete_increment_hit_count_cache_timestamp(sender, instance, **kwargs):
-    # always bump it
-    import mysite.base.models
-    mysite.base.models.Timestamp.update_timestamp_for_string(
-        'hit_count_cache_timestamp'),
+def post_bug_save_delete_increment_hit_count_cache_timestamp(sender, instance, raw, **kwargs):
+    if not raw:
+        # always bump it, unless we're loading a data snapshot
+        import mysite.base.models
+        mysite.base.models.Timestamp.update_timestamp_for_string(
+            'hit_count_cache_timestamp'),
 
 # Clear the hit count cache whenever Bugs are added or removed. This is
 # simply done by bumping the Timestamp used to generate the cache keys.


### PR DESCRIPTION
3/4 functions used as handlers in models.signals.post_save.connect() calls were modified to not execute if raw is True.
