### PR TITLE
Fixed #990 Deleted references to geolocation, maps, guessing location

### DIFF
--- a/mysite/account/templates/account/set_location.html
+++ b/mysite/account/templates/account/set_location.html
@@ -20,7 +20,7 @@
 
 
 {% block title %}
-Put yourself on the map - 
+Change your location - 
 {{ block.super }}
 {% endblock title %}
 
@@ -29,38 +29,20 @@ Put yourself on the map -
 {% endblock form_action %}
 
 {% block submodule_head %}
-Put yourself on the map
+Change your location
 {% endblock submodule_head %}
 
 {% block submodule_body %}
 {% if user.get_profile.location_display_name %}
-<p style="visibility: hidden;" id="success_message">Your location is visible on <a href="{%url mysite.profile.views.people %}">the global map</a>.
+<p id="success_message">
 If you want us to forget your location, empty out the text field and hit save.</p>
 {% else %}
-<p>To appear on <a href="{%url mysite.profile.views.people %}">the global map</a>,
-  set a location.</p>
 {% endif %}
-{% if not user.get_profile.location_confirmed and user.get_profile.location_display_name and not user.get_profile.dont_guess_my_location  and not dont_suggest_location %}
-<p>
-  <label></label>
-  <span class="notification" style="width: 311px; margin-bottom: 0;">We've tried to guess your location.</span>
-</p>
-{% endif %}
-{{ edit_location_form.as_p }}
 
-{% if user.get_profile.location_display_name %}
-<div style="position: relative; left: -16px;">
-  <label style="visibility: hidden;" id="geocode_description">You on a map! <br /><br />(If we got it wrong, try being more specific.)
-</label>
-<div id="map_canvas" style="float: left; width: 311px; height: 250px;">Loading map&hellip;</div>
-</div>
-{% endif %}
+{{ edit_location_form.as_p }}
 
 {% endblock submodule_body %}
 
-{% block js_in_head %}
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
-{% endblock js_in_head %}
 
 {% block js %}
 <script type="text/javascript">

--- a/mysite/account/templates/account/settings.html
+++ b/mysite/account/templates/account/settings.html
@@ -46,14 +46,9 @@ Settings
                             font-weight: bold;
                         }
                     </style>
-                    <li id='link-set_location'>
-                    <a href='{% url account.views.set_location %}'>
-                        Put yourself on the map
-                    </a>
-                    </li>
-                    <li id='link-edit_contact_info'>
-                    <a href='{% url account.views.edit_contact_info %}'>
-                        Email
+                    <li id='link-invite_someone'>
+                    <a href='{% url account.views.invite_someone %}'>
+                        Tell a friend about OpenHatch
                     </a>
                     </li>
                     <li id='link-widget'>
@@ -61,9 +56,14 @@ Settings
                         Widgetize yourself
                     </a>
                     </li>
-                    <li id='link-invite_someone'>
-                    <a href='{% url account.views.invite_someone %}'>
-                        Tell a friend about OpenHatch
+                    <li id='link-set_location'>
+                    <a href='{% url account.views.set_location %}'>
+                        Location
+                    </a>
+                    </li>
+                    <li id='link-edit_contact_info'>
+                    <a href='{% url account.views.edit_contact_info %}'>
+                        Email
                     </a>
                     </li>
                     <li id='link-edit_name'>

--- a/mysite/account/tests.py
+++ b/mysite/account/tests.py
@@ -1,4 +1,3 @@
-# This file is part of OpenHatch.
 # Copyright (C) 2010 Parker Phinney
 # Copyright (C) 2009, 2010 OpenHatch, Inc.
 # Copyright (C) 2010 Jessica McKellar
@@ -382,77 +381,6 @@ class EditPhotoWithOldPerson(TwillTests):
                          open(image).read())
     #}}}
 
-
-class GuessLocationOnLogin(TwillTests):
-    #{{{
-    fixtures = ['user-paulproteus', 'person-paulproteus']
-
-    mock_ip = mock.Mock()
-    # Located in Rochester, New York, U.S.A.
-    mock_ip.return_value = "128.151.2.1"
-
-    @skipIf(not mysite.profile.view_helpers.geoip_city_database_available(), "Skipping because high-resolution GeoIP data not available.")
-    @mock.patch("mysite.base.middleware.get_user_ip", mock_ip)
-    def test_guess_location_on_accessing_edit_location_form(self):
-        person = Person.objects.get(user__username="paulproteus")
-        self.assertFalse(person.location_confirmed)
-        self.assertEqual('Inaccessible Island',
-                         person.get_public_location_or_default())
-
-        client = self.login_with_client()
-        response = client.get(reverse(mysite.account.views.set_location))
-        self.assertContains(response, "OpenHatch")
-        self.assertContains(response, "Rochester, NY, United States")
-
-    mock_ip = mock.Mock()
-    # Located in Rochester, New York, U.S.A.
-    mock_ip.return_value = "128.151.2.1"
-
-    @skipIf(not mysite.profile.view_helpers.geoip_city_database_available(), "Skipping because high-resolution GeoIP data not available.")
-    @mock.patch("mysite.base.middleware.get_user_ip", mock_ip)
-    def test_do_not_guess_if_have_location_set(self):
-        person = Person.objects.get(user__username="paulproteus")
-        person.location_display_name = 'The White House'
-        person.latitude = 38.898748
-        person.longitude = -77.037684
-        person.location_confirmed = True
-        person.save()
-
-        client = self.login_with_client()
-        response = client.get(reverse(mysite.account.views.set_location))
-        self.assertContains(response, "OpenHatch")
-        self.assertNotContains(response, "Rochester, NY, United States")
-        self.assertContains(response, "The White House")
-
-    def test_yes_response(self):
-        person = Person.objects.get(user__username="paulproteus")
-        # logging in
-        client = self.login_with_client()
-        # sending http request to correct page for "yes" response
-        response = client.post(
-            reverse(mysite.account.views.confirm_location_suggestion_do))
-        # asserting that we get back an http status code of 200
-        self.assertEqual(response.status_code, 200)
-        # client.post modifies person, refetching to check update...
-        person = Person.objects.get(user__username="paulproteus")
-        # asserting that database was updated
-        self.assertTrue(person.location_confirmed)
-
-    def test_dont_guess_response(self):
-        person = Person.objects.get(user__username="paulproteus")
-        # logging in
-        client = self.login_with_client()
-        # sending http request to correct page for "don't guess" response
-        response = client.post(
-            reverse(mysite.account.views.dont_guess_location_do))
-        # asserting that we get back an http status code of 200
-        self.assertEqual(response.status_code, 200)
-        # client.post modifies person, refetching to check update...
-        person = Person.objects.get(user__username="paulproteus")
-        # asserting that database was updated
-        self.assertTrue(person.dont_guess_my_location)
-
-    #}}}
 
 
 class SignupWithNoPassword(TwillTests):

--- a/mysite/account/views.py
+++ b/mysite/account/views.py
@@ -286,9 +286,7 @@ def set_location(request, edit_location_form=None):
     if (not request.user.get_profile().location_display_name) or (
         request.user.get_profile().location_display_name ==
             mysite.profile.models.DEFAULT_LOCATION):
-        geoip_guess = mysite.profile.view_helpers.get_geoip_guess_for_ip(
-            mysite.base.middleware.get_user_ip(request))[1]
-        initial['location_display_name'] = geoip_guess
+        initial['location_display_name'] = "Inaccessible Island"
     else:
         initial['location_display_name'] = request.user.get_profile(
         ).location_display_name
@@ -335,23 +333,6 @@ def set_location_do(request):
     else:
         return set_location(request,
                             edit_location_form=edit_location_form)
-
-
-@login_required
-def confirm_location_suggestion_do(request):
-    person = request.user.get_profile()
-    person.location_confirmed = True
-    person.save()
-    return HttpResponse()
-
-
-@login_required
-def dont_guess_location_do(request):
-    person = request.user.get_profile()
-    person.dont_guess_my_location = True
-    person.location_display_name = ''
-    person.save()
-    return HttpResponse()
 
 
 @login_required

--- a/mysite/base/templates/base/nav.html
+++ b/mysite/base/templates/base/nav.html
@@ -36,7 +36,7 @@
         <ul id='account-links'>
             {% if user.is_authenticated %}
                 <li><a href='{% url oh_logout %}?next={% if go_here_after_logging_in_or_out %}{{ go_here_after_logging_in_or_out|urlencode }}{% else %}/{% endif %}'>log out</a></li>
-                <li><a href='{% url mysite.account.views.set_location %}'>settings</a></li>
+                <li><a href='{% url mysite.account.views.invite_someone  %}'>settings</a></li>
                 <li><a href='{% url mysite.profile.views.display_person_web user.username %}'>
                 {% with user.get_profile as person %}
                     {% if person.user.first_name or person.user.last_name %}

--- a/mysite/profile/templates/profile/base_profile.html
+++ b/mysite/profile/templates/profile/base_profile.html
@@ -67,7 +67,6 @@
 
 	    <div style="clear: left; float: left;">
 	      {% if person.location_display_name and person.location_confirmed %}
-              <a style='color: #555;' href="/people/?center={{ person.location_display_name }}">
               {{ person.location_display_name }}
           </a>
 	      {% endif %}

--- a/mysite/static/js/account/set_location.js
+++ b/mysite/static/js/account/set_location.js
@@ -42,7 +42,6 @@ function initialize() {
                     'title': 'You',
                     'position': results[0].geometry.location
                     });
-            $('#geocode_description').css('visibility', 'visible');
             $('#success_message').css('visibility', 'visible');
         }
         else {

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -361,12 +361,6 @@ urlpatterns = patterns('',
                        (r'^account/settings/location/do$',
                         'mysite.account.views.set_location_do'),
 
-                       (r'^account/settings/location/confirm_suggestion/do$',
-                        'mysite.account.views.confirm_location_suggestion_do'),
-
-                       (r'^account/settings/location/dont_guess_location/do$',
-                        'mysite.account.views.dont_guess_location_do'),
-
                        (r'^account/settings/invite_someone/$',
                         'mysite.account.views.invite_someone'),
 


### PR DESCRIPTION
Closes https://openhatch.org/bugs/issue990.

Deleted code in the settings page that has any mention of geolocation and maps,
including geo-location-related html, views, and tests.

Changed default url link "settings" on header from
/settings/location/ to /settings/invite_someone.

Made design decision to re-structure left-hand navigation bar on
settings page in order to improve UI:
    "Tell friend about OpenHatch" tab appears first on top left,
    followed by the "Widgetize yourself" tab, and finally,
    the "Email", "Name", and "Password" navigation tabs.
