### PR TITLE
Replaced the broken link to the Contributor Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Contributing to OpenHatch
 =========================
 
-Before opening a pull request or submitting a patch, please [read the guidelines for contributing](http://openhatch.readthedocs.org/en/latest/contributor/index.html).
+Before opening a pull request or submitting a patch, please [read the guidelines for contributing](http://openhatch.readthedocs.org/en/latest/getting_started/getting_started.html).
 
 If you submit more than one pull request, you'll find that it's helpful to use a topic branch to avoid duplicating commits.


### PR DESCRIPTION
Fixed: Issue 996 Link to the Contributor Guide in CONTRIBUTING.md is broken 
