### PR TITLE
Converted CONTRIBUTING.md to CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,0 @@
-Contributing to OpenHatch
-=========================
-
-Before opening a pull request or submitting a patch, please [read the guidelines for contributing](http://openhatch.readthedocs.org/en/latest/getting_started/getting_started.html).
-
-If you submit more than one pull request, you'll find that it's helpful to use a topic branch to avoid duplicating commits.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,11 @@
+=========================
+Contributing to OpenHatch
+=========================
+
+Before opening a pull request or submitting a patch, please `read the guidelines for contributing`_.
+
+If you submit more than one pull request, you'll find that it's helpful to use a topic branch to avoid duplicating commits.
+
+.. _read the guidelines for contributing: http://openhatch.readthedocs.org/en/latest/getting_started/getting_started.html
+
+.. Further changes to this file should be made using the limited subset of rST syntax that GitHub supports.

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -1,0 +1,11 @@
+=========================
+Contributing to OpenHatch
+=========================
+
+Before opening a pull request or submitting a patch, please `read the guidelines for contributing`_.
+
+If you submit more than one pull request, you'll find that it's helpful to use a topic branch to avoid duplicating commits.
+
+.. _read the guidelines for contributing: http://openhatch.readthedocs.org/en/latest/getting_started/getting_started.html
+
+.. Further changes to this file should be made using the limited subset of rST syntax that GitHub supports.


### PR DESCRIPTION
Fixed: Issue 999 Adjust CONTRIBUTING.md to use Sphinx's :doc: or :ref: syntax to link to the Contributor Guide http://openhatch.org/bugs/issue999.
