### PR TITLE
Fixed tar mission's Quick reference page

### DIFF
--- a/mysite/missions/templates/missions/tar/hints.html
+++ b/mysite/missions/templates/missions/tar/hints.html
@@ -39,7 +39,7 @@
       <p>So the command would look something like:</p>
       <pre>tar <em>[option letters]</em>tf <em>[tarball]</em></pre>
       <p>(The <tt>t</tt> stands for lis<strong>t</strong>.  Go figure.)</p>
-      <p>Option letter <tt>v</tt>, which would otherwise be redundant because tar is already listing the contents as it examines the tarball, shows more details (such as permissions and sizes) about the files inside.<p>
+      <p>Option letter <tt>v</tt>, which would otherwise be redundant because tar is already listing the contents as it examines the tarball, shows more details (such as permissions and sizes) about the files inside.</p>
 
       <p>It is generally a good idea to try unpacking or listing a tarball you are about to send out so you can verify that it really contains what you wanted.</p>
 


### PR DESCRIPTION
Fixed: Issue 1008 Text formatting in missions/tar/hints is messed up https://openhatch.org/bugs/issue1008.
