### PR TITLE
Comment out image on 500 error page

### DIFF
--- a/mysite/base/templates/500.html
+++ b/mysite/base/templates/500.html
@@ -34,7 +34,9 @@ Error
         <h3 style='font-family: "Comic Sans MS"; font-size: 15pt;'>Error 500 (server error)</h3>
     </div>
     <div class='module-body'>
-        <img src={% version '/static/images/asheesh-fail.jpg' %}>
+# TODO consider changing image to one that doesn't have "suck" in background
+#      disabling image pending better solution
+#       <img src={% version '/static/images/asheesh-fail.jpg' %}>
         <p>You requested a page, and we really wanted to give it
         to you. But we messed up. Sorry about that!</p>
 
@@ -43,7 +45,7 @@ Error
         us get it fixed, <a href="/contact/">contact us</a>.)
         </p>
 
-        <p><small>Photo credit: <cite>Technically Philly</cite> from this <a href='http://technicallyphilly.com/2010/03/03/ignite-philly-5-social-entrepreneurs-google-bid'>blog post</a>.</small></p>
+# TODO uncomment and photo credit when new image is enabled  <p><small>Photo credit: <cite>Technically Philly</cite> from this <a href='http://technicallyphilly.com/2010/03/03/ignite-philly-5-social-entrepreneurs-google-bid'>blog post</a>.</small></p>
     </div>
 </div>
 {% endblock main %}


### PR DESCRIPTION
Submitted as a partial, temporary solution for Issue 1011.

Commented out 500 error page image so that the page will not display any image. Team should consider whether a different image may be more suitable or professional.
