### PR TITLE
Add csrf tocken to post request that resets mission state.

### DIFF
--- a/mysite/static/js/missions/base.js
+++ b/mysite/static/js/missions/base.js
@@ -24,7 +24,8 @@ $(function() {
         function() {
             $.post(
                 OH.Page['post_url'],
-                { mission_parts: OH.Page['mission_parts'] },
+                { 'csrfmiddlewaretoken': $.cookie('csrftoken'),
+                  mission_parts: OH.Page['mission_parts'] },
                 function(response) {
                     var items = ['#success-msg', '#next-mission-link'];
                     var len = items.length;


### PR DESCRIPTION
Resetting mission state doesn't work now because of missing csrf token. This fixes the issue.

Also, resetting mission is broken since the security upgrade, but our tests didn't catch it. Does anyone has any idea how to write tests to cover cases like these? (We probably have to automate the post request in the javascript portion of the code and then see if it succeeded.)
