### PR TITLE
Fixed profile_hourly_tasks.py

### DIFF
--- a/mysite/profile/management/commands/profile_hourly_tasks.py
+++ b/mysite/profile/management/commands/profile_hourly_tasks.py
@@ -47,9 +47,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         rootLogger = logging.getLogger('')
         rootLogger.setLevel(logging.WARN)
-        mysite.profile.tasks.sync_bug_timestamp_from_model_then_fill_recommended_bugs_cache(
-        )
-        mysite.profile.tasks.fill_recommended_bugs_cache()
 
         # Every 4 hours, clear search cache
         if (datetime.datetime.utcnow().hour % 4) == 0:


### PR DESCRIPTION
Fixed: Issue 1016 Cron deploy@linode cd $HOME/milestone-a ; ./mysite/scripts/run_with_lock.sh python manage.py profile_hourly_tasks 2>&1 | grep -v DeprecationWarning | grep -v 'import ' | grep -v SubfieldBase (fwd) https://openhatch.org/bugs/issue1016

I tested my fix by typing the following command into the command line manually:
 ./mysite/scripts/run_with_lock.sh python manage.py profile_hourly_tasks 2>&1 | grep -v DeprecationWarning | grep -v 'import ' | grep -v SubfieldBase 

I am not sure whether this is the best way to test this, but profile_hourly_tasks.py does not throw an exception after this fix and test. @paulproteus also suggested that  I write a unittest for this command but I wasn't able to figure out how to do this as I have never worked with tests before. I would be willing to work on the tests but I feel that I would need some guidance from paulproteus to do this. :)
