### PR TITLE
Fix any and all pages caused by Django 1.5 url syntax

### DIFF
--- a/mysite/account/templates/account/settings.html
+++ b/mysite/account/templates/account/settings.html
@@ -62,12 +62,12 @@ Settings
                     </a>
                     </li>
                     <li id='link-set_location'>
-                    <a href='{% url account.views.set_location %}'>
+                    <a href='{% url "account.views.set_location" %}'>
                         Location
                     </a>
                     </li>
                     <li id='link-edit_contact_info'>
-                    <a href='{% url account.views.edit_contact_info %}'>
+                    <a href='{% url "account.views.edit_contact_info" %}'>
                         Email
                     <li id='link-invite_someone'>
                     <a href='{% url "account.views.invite_someone" %}'>

--- a/mysite/account/templates/authopenid/signin.html
+++ b/mysite/account/templates/authopenid/signin.html
@@ -17,7 +17,7 @@
 {% endcomment %}
 {% load i18n %}
 
-<form id="openid_form" name="openid_form" action="{% url user_signin %}" method="post">{% csrf_token %}
+<form id="openid_form" name="openid_form" action="{% url "user_signin" %}" method="post">{% csrf_token %}
     <input type="hidden" name="action" value="verify" />
     <input type="hidden" name="next" value="{{ next }}" />
         <fieldset>

--- a/mysite/base/templates/base/guide.html
+++ b/mysite/base/templates/base/guide.html
@@ -85,7 +85,7 @@ document.documentElement.className = 'javascript_is_enabled';
      <div id="portfolio_editor" class="tab">
 	  <p>You can start by letting new contributors know about your project.</p>
 	  <ul class="raquo_bullets fairly-big">
-	    <li><a href='{% url mysite.profile.views.portfolio_editor %}'>Add a project</a> and  describe your involvement.</li>
+	    <li><a href='{% url "mysite.profile.views.portfolio_editor" %}'>Add a project</a> and  describe your involvement.</li>
 	    <li>Once your project has been added you can proceed towards adding its bug tracker.
 	    	<span class="normal-size"><a href="/wiki/Bug_trackers">(instructions)</a>
 	    	</span>


### PR DESCRIPTION
The "account/settings/location/" was broken, so it's fixed now in the
templates.
