### PR TITLE
Remove url.conf.defaults deprecation warns from Django 1.5 upgrade

### DIFF
--- a/mysite/missions/base/views.py
+++ b/mysite/missions/base/views.py
@@ -26,7 +26,7 @@ from mysite.missions.models import Step, StepCompletion
 from mysite.missions.base import view_helpers
 
 from django.http import HttpResponseRedirect, HttpResponse, Http404, HttpResponseNotAllowed
-from django.conf.urls.defaults import (
+from django.conf.urls import (
     url,
     patterns,
 )

--- a/mysite/project/urls.py
+++ b/mysite/project/urls.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('mysite.project.views',
 

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls.defaults import patterns, url, include, handler404
+from django.conf.urls import patterns, url, include, handler404
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import redirect
 


### PR DESCRIPTION
Change the names of the url.conf imports to be compatible with Django
1.5 syntax.

Resolves https://github.com/openhatch/oh-mainline/issues/1366

Note that there is still 1 warning in the full test suite that this `url.conf.defaults` is still here, most likely due to 3rd party `vendor/packages/` code but all the OH code no longer references any such `url.conf.defaults`.
