### PR TITLE
Correct filter setting for mail-admin for Django 1.4+

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -325,7 +325,7 @@ LOGGING = {
         },
         'mail_admins': {
             'level': 'ERROR',
-            #            'filters': ['require_debug_false'],
+            'filters': [],
             'class': 'django.utils.log.AdminEmailHandler'
         },
     },


### PR DESCRIPTION
This PR corrects the warnings about filter settings in mail-admin that were appearing in the test runs after the Django upgrades.
