### PR TITLE
Use protocol relative link for training missions

### DIFF
--- a/mysite/base/templates/base/donate.html
+++ b/mysite/base/templates/base/donate.html
@@ -361,7 +361,7 @@
                         <p>
                             Tarashish Mistra ("sunu" in #openhatch) has been working on modernizing the OpenHatch training missions by rewriting them on top of AngularJS and <a href="https://code.google.com/p/oppia/">Oppia</a>, an open source interactive teaching framework built at Google. You can track his progress at
                             <a href="https://github.com/openhatch/oh-missions-oppia-beta">https://github.com/openhatch/oh-missions-oppia-beta</a>
-                            , and try out the beta at <a href="http://missions-beta.openhatch.org">http://missions-beta.openhatch.org</a>. Work progresses on merging this into the main openhatch.org website.
+                            , and try out the beta at <a href="//missions-beta.openhatch.org">//missions-beta.openhatch.org</a>. Work progresses on merging this into the main openhatch.org website.
                         </p>
                     </div>
                     <div class="col-sm-6">

--- a/mysite/missions/templates/missions/tar/about.html
+++ b/mysite/missions/templates/missions/tar/about.html
@@ -43,7 +43,7 @@
       </div>
       {% endif %}
       <div class="mission-step">
-        <oppia oppia-id="10" exploration-version="1" src="http://missions-beta.openhatch.org">
+        <oppia oppia-id="10" exploration-version="1" src="//missions-beta.openhatch.org">
       </div>
   </div>
 </div>

--- a/mysite/missions/templates/missions/tar/creating.html
+++ b/mysite/missions/templates/missions/tar/creating.html
@@ -44,7 +44,7 @@
       <!-- create status: failure -->
       {% endif %}
       <div class="mission-step">
-        <oppia oppia-id="11" exploration-version="3" src="http://missions-beta.openhatch.org">
+        <oppia oppia-id="11" exploration-version="3" src="//missions-beta.openhatch.org">
       </div>
       <script type="text/javascript">
         window.OPPIA_PLAYER.onStateTransitionPostHook = function(

--- a/mysite/missions/templates/missions/tar/unpacking.html
+++ b/mysite/missions/templates/missions/tar/unpacking.html
@@ -41,7 +41,7 @@
       </div>
       {% endif %}
       <div class="mission-step">
-        <oppia oppia-id="12" exploration-version="4" src="http://missions-beta.openhatch.org">
+        <oppia oppia-id="12" exploration-version="4" src="//missions-beta.openhatch.org">
       </div>
       <script type="text/javascript">
         window.OPPIA_PLAYER.onStateTransitionPostHook = function(


### PR DESCRIPTION
This change means that on HTTPS pages, we will use a HTTPS IFRAME URL
for the Oppia instance.

Refs #1348
