### PR TITLE
Adds doc on issue tracking and fixes small indent error #1404

### DIFF
--- a/docs/community/quotes_db.rst
+++ b/docs/community/quotes_db.rst
@@ -38,7 +38,7 @@ How to approve quotes
 ---------------------
 
 * Visit the login page at
-http://boiling-refuge-7775.herokuapp.com/?m=userlogin
+  http://boiling-refuge-7775.herokuapp.com/?m=userlogin
 
 * Log in (if you need an account, ask paulproteus)
 

--- a/docs/internals/index.rst
+++ b/docs/internals/index.rst
@@ -15,6 +15,7 @@ Here's more information about our project structure that may be useful.
   front_end_style_guide
   api
   pull_request_linting
+  issue_tracking
 
 Sections to add:
 

--- a/docs/internals/issue_tracking.rst
+++ b/docs/internals/issue_tracking.rst
@@ -1,0 +1,31 @@
+==================================
+Issue tracking using GitHub Issues
+==================================
+
+Overview
+========
+
+We use `GitHub Issues`_ for tracking issues. The `Managing Projects`_ section of
+`GitHub Help`_ provides useful information about filtering, sorting, assigning,
+and labeling issues.
+
+.. _`GitHub Issues`: https://github.com/openhatch/oh-mainline/issues
+.. _`Managing Projects`: https://help.github.com/categories/100/articles
+.. _`GitHub Help`: https://help.github.com/
+
+Issue labels
+============
+
+We use `Labels` to categorize an issue's priority, status, and type as well as
+other helpful user information. The `Bitesize` label is used to indicate that
+the issue is suitable for a new contributor to the project.
+
+Historical note on issue tracking
+=================================
+
+Prior to using `GitHub Issues`, we used two other issue trackers. To preserve
+historical information, issues that were imported from past trackers can be
+identified by the user creator (@imported-from-roundup in the oh-mainline repo
+and @bot-sunu in the oh-bugimporters repo).
+
+


### PR DESCRIPTION
Documents the basics of OpenHatch and GitHub Issues. Highlights the imported names from prior issue trackers. 

Fixes indent error that Sphinx was complaining about when rendering the docs.
