### PR TITLE
Simplify the deploy script

### DIFF
--- a/mysite/scripts/deploy
+++ b/mysite/scripts/deploy
@@ -2,12 +2,7 @@
 set -x
 set -e
 
-### First, make sure that origin/master
-### contains the current git repo contents.
-
-git push origin HEAD:master
-
-### Then, ssh to deploy@linode.openhatch.org
+### ssh to deploy@linode.openhatch.org
 ### and update the site.
 ssh -t deploy@linode.openhatch.org milestone-a/mysite/scripts/deploy_myself.sh
 


### PR DESCRIPTION
Back in the day, the deploy script would also do a git push. This removes that
from the deploy script, and assumes that whatever is on the main git repository
as master is what you want to deploy.

This also means we can simplify the docs around the deploy script, because after
this change, it no longer depends on the local git configuration.
