### PR TITLE
Store production-usable SMTP config in deployment_settings

### DIFF
--- a/mysite/deployment_settings.py
+++ b/mysite/deployment_settings.py
@@ -73,3 +73,11 @@ ALLOWED_HOSTS=['testserver', 'openhatch.org']
 # This path is important because the nginx
 # configuration is consistent with it.
 STATIC_ROOT='/home/deploy/milestone-a/mysite/statik'
+
+# In production, we use localhost port 25 SMTP.
+#
+# settings.py explains how to get email working in
+# development via a debugging-oriented SMTP server.
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = '127.0.0.1'
+EMAIL_PORT = 25


### PR DESCRIPTION
Since d5e1cc9f3664de6019c11461b92245b8c0eb0e69 , we have a debugging-oriented SMTP
server explained in settings.py. If we deploy this commit, we will use the same
setting in production, which is not consistent with how email sending works on
linode.openhatch.org.

This setting therefore makes that explicit, thereby fixing outbound email
in production again.
