### PR TITLE
Remove deployment_settings.py from coverage checking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ omit =
     */migrations/*
     tests.py
     settings.py
+    deployment_settings.py


### PR DESCRIPTION
We do not really test the deployment_settings.py file, and that is OK.

No need for coveralls etc. to become unhappy that coverage decreases when
that file gets longer.
