### PR TITLE
Provide DJANGO_SETTINGS_MODULE when vaidating YAML

### DIFF
--- a/run_importer.sh
+++ b/run_importer.sh
@@ -36,7 +36,7 @@ function grab_bug_tracker_list() {
     # is it a "helpful" CloudFlare error message? To do this
     # check, we ask Python to parse this document, and if it
     # bails out, then we also return 1.
-    python -c "import vendor; vendor.vendorify(); import tastypie.serializers; import yaml; yaml.load(open('$BUG_TRACKER_LIST'), Loader=tastypie.serializers.TastypieLoader)" || return 1
+    DJANGO_SETTINGS_MODULE='mysite.settings' python -c "import vendor; vendor.vendorify(); import tastypie.serializers; import yaml; yaml.load(open('$BUG_TRACKER_LIST'), Loader=tastypie.serializers.TastypieLoader)" || return 1
 
     # Amazing. It is valid YAML. Exit succesfully.
     return 0


### PR DESCRIPTION
tastypie.serializers depends on django.core.serializers.json,
which depends on django.db.models, which will only import
if the settings object is properly configured, so before this
commit, we would crash with:

django.core.exceptions.ImproperlyConfigured: Requested setting DATABASES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.

See http://inside.openhatch.org/crawl-logs/scrapy.2014-09-07.atP3.log
(which may be deleted due to log rotation) for the full traceback.
