### PR TITLE
Use system json module, not Django simplejson

### DIFF
--- a/mysite/customs/management/commands/snapshot_public_data.py
+++ b/mysite/customs/management/commands/snapshot_public_data.py
@@ -21,7 +21,7 @@ from mysite.search.models import Bug, Project
 from mysite.profile.models import Person, Tag, TagType, Link_Person_Tag
 from mysite.base.models import Timestamp
 import sys
-from django.utils import simplejson
+import json
 from django.core.management.base import BaseCommand
 import django.core.serializers
 import django.core.serializers.json
@@ -152,5 +152,5 @@ class Command(BaseCommand):
         data.extend(public_persons_tags_links)
 
         # anyway, now we stream all this data out using simplejson
-        simplejson.dump(data, output,
+        json.dump(data, output,
                         cls=django.core.serializers.json.DjangoJSONEncoder)


### PR DESCRIPTION
Fix #1383

Thanks to @willingc for pointing out the simplejson deprecation,
and to @ehashman for filing the bug.

I've tested this patch on linode2.openhatch.org, and it generates
a data snapshot without crashing.
