### PR TITLE
Kicking off new bug trackers (for a project) properly

### DIFF
--- a/run_importer.sh
+++ b/run_importer.sh
@@ -25,7 +25,7 @@ if [ ! -z "$3" ] ; then
     TRACKER_ID="$3"
 fi
 
-URL=https://openhatch.org/+api/v1/customs/tracker_model/\?include_empty\=yes\&just_stale\=yes\&format\=yaml\&limit\="$MAX_TRACKERS"\&tracker_id="$TRACKER_ID"
+URL=https://openhatch.org/+api/v1/customs/tracker_model/\?just_stale\=yes\&format\=yaml\&limit\="$MAX_TRACKERS"\&tracker_id="$TRACKER_ID"
 
 function grab_bug_tracker_list() {
     # Try to download $URL. If curl bails on us, then


### PR DESCRIPTION
This patch adds a new API option 'include_empty' to customs/api.py, for kicking off new trackers/projects when also specifying the 'just_stale' switch. So far, new projects had an empty bug list and wouldn't be included in the results...and therefore wouldn't get scraped for new bugs initially.
