### PR TITLE
Updated GitHub URL regex.

### DIFF
--- a/mysite/customs/forms.py
+++ b/mysite/customs/forms.py
@@ -159,7 +159,7 @@ class GitHubTrackerForm(TrackerFormThatHidesCreatedForProject):
         github_url = self.cleaned_data['github_url']
 
         github_name_repo = re.match(
-            r'^https?:\/\/github.com\/([\_\-\w]+)\/([\_\-\w]+)$',
+            r'^https?:\/\/github.com\/([\_\-\w]+)\/([\_\-\w.]+)$',
             github_url
         )
 


### PR DESCRIPTION
fixes #1456.

GitHub project names are allowed to have dots in them. https://github.com/gratipay/gratipay.com for example.
