### PR TITLE
Relocate subversion path setting in svnadmin_available() to settings.py

### DIFF
--- a/docs/advanced/advanced_testing.rst
+++ b/docs/advanced/advanced_testing.rst
@@ -123,6 +123,15 @@ following convenience methods:
     * `login_with_client`
     * `login_with_twill`
 
+The subversion missions test cases
+**********************************
+When running or testing the subversion mission locally, subversion (svn
+and svnadmin) must be installed on the local system. If subversion is
+not installed, the tests will not be run. 
+
+Settings information related to subversion, such as path locations, can
+be found in the `settings.py`.
+
 About fixtures
 ##############
 .. note:: Twill is going away in the OpenHatch code base and is being

--- a/mysite/base/depends.py
+++ b/mysite/base/depends.py
@@ -25,17 +25,14 @@
 # This is so that new contributors can run the OpenHatch site without
 # installing these hard-to-install dependencies.
 
-# Used within this file
 import os
 import logging
-
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 
 # Wrap lxml and the modules that are part of it
-
-
 class nothing(object):
     pass
 
@@ -53,15 +50,11 @@ if lxml.html is None:
                 "lxml library is not installed. Look in "
                 "ADVANCED_INSTALLATION.mkd for information about lxml.")
 
-# Provide a helper to check if svnadmin is available. If not,
-# we can skip running code (and tests) that require it.
 
-
+# Helper to check if svnadmin is available. If not,
+# we can skip running 'missions' code (and tests) that require it.
 def svnadmin_available():
-    # FIXME: This should move to a variable controlled
-    # by settings.py.
-    SVNADMIN_PATH = '/usr/bin/svnadmin'
-    return os.path.exists(SVNADMIN_PATH)
+      return os.path.exists(settings.SVNADMIN_PATH)
 
 # Here we try to import "Image", from the Python Imaging Library.
 # If we fail, Image is None.

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -287,6 +287,9 @@ SVN_REPO_PATH = os.path.abspath(
 # For local sites, this is what you checkout
 SVN_REPO_URL_PREFIX = 'file://' + SVN_REPO_PATH + '/'
 
+# This path is used when determining whether to run svn mission tests
+SVNADMIN_PATH = '/usr/bin/svnadmin'
+
 # The script to invoke for management commands in this environment.
 PATH_TO_MANAGEMENT_SCRIPT = os.path.abspath(
     os.path.join(DIRECTORY_CONTAINING_SETTINGS_PY, '../manage.py'))

--- a/mysite/testrunner.py
+++ b/mysite/testrunner.py
@@ -45,6 +45,7 @@ def override_settings_for_testing():
     settings.POSTFIX_FORWARDER_TABLE_PATH = generate_safe_temp_file_name()
 
     svnserve_port = random.randint(50000, 50100)
+
     if mysite.base.depends.svnadmin_available():
         subprocess.check_call(['svnserve',
                                '--listen-port', str(svnserve_port),


### PR DESCRIPTION
When reviewing the testrunner code, I noticed that the SVNADMIN_PATH was being set in `mysite.base.depends.py`. It really should be set in the `settings.py` file. 

I also added a section to the advanced testing documentation that points out that the subversion mission tests depend on svn and svnadmin being installed to run.
