### PR TITLE
Catching server error in  start and end query parameters for  mysite/search/?q=&start=1&end=20

### DIFF
--- a/mysite/search/views.py
+++ b/mysite/search/views.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.http import HttpResponse, QueryDict, HttpResponseServerError, HttpResponseRedirect
+from django.http import HttpResponse, QueryDict, HttpResponseServerError, HttpResponseRedirect,Http404
 from django.core import serializers
 from django.shortcuts import get_object_or_404
 from django.core.urlresolvers import reverse
@@ -67,8 +67,15 @@ def search_index(request, invalid_subscribe_to_alert_form=None):
     suggestions = [(i, k, False) for i, k in enumerate(suggestion_keys)]
 
     format = request.GET.get('format', None)
-    start = int(request.GET.get('start', 1))
-    end = int(request.GET.get('end', 10))
+
+    # check if the query dont give (server error 500) exception
+    try:
+        start = int(request.GET.get('start', 1))
+        end = int(request.GET.get('end', 10))
+    except (ValueError,AssertionError):
+        raise Http404
+    if start < 1 or end < 1:
+        raise Http404
 
     total_bug_count = 0
 


### PR DESCRIPTION
@paulproteus  I want to resolve #1332 I have caught the exceptions which will raise Http404
to the unusual query parameters 
if we go to  http://openhatch.org/search/?q=&language=Python
and then the following query parameters http://openhatch.org/search/?q=&start=11&end=20&language=Python
and replace the numbers with characters http://openhatch.org/search/?q=&start=banana&end=20&language=Python
we get the error page.I hav modified it to 404 page as the issue suggested.
I am new as a contributor (apology if any mistakes) but another part of the pull request is writing unittests
I would be very greatful if some one can guide me with writing unittests for  /oh-mainline/mysite/search/test.py...query parameters
