### PR TITLE
css box alignments for widgets in front page

### DIFF
--- a/mysite/static/less/base/base.less
+++ b/mysite/static/less/base/base.less
@@ -300,7 +300,8 @@ img.right { float: right; padding: 0 0 @standard-padding 10px;}
 }
 .column {
     float: left;
-    margin-right: 10px;
+    margin-left: -1px;
+    width:32%;
 }
 h4, .cute-header {
     font-size: 9pt;


### PR DESCRIPTION
![css_fix](https://cloud.githubusercontent.com/assets/6047805/5004371/99f2979a-6a41-11e4-8d01-15dccbc3a608.png)

I have resolved the issue  #1369.. relating to the front-page
