### PR TITLE
Remove obsolete Ohloh functions and tests

### DIFF
--- a/mysite/customs/tests.py
+++ b/mysite/customs/tests.py
@@ -319,8 +319,7 @@ class DataExport(django.test.TestCase):
             key=TIMESTAMP_KEY_TO_USE)
         self.assertEquals(reincarnated_t.timestamp, TIMESTAMP_DATE_TO_USE)
 
-    @mock.patch('mysite.search.tasks.PopulateProjectIconFromOhloh')
-    def test_snapshot_project(self, fake_icon):
+    def test_snapshot_project(self):
         fake_stdout = StringIO()
         # make fake Project
         proj = Project.create_dummy_no_icon(

--- a/mysite/project/tests.py
+++ b/mysite/project/tests.py
@@ -111,9 +111,7 @@ class ProjectList(TwillTests):
 class ProjectPageCreation(TwillTests):
     fixtures = ['user-paulproteus', 'person-paulproteus']
 
-    @mock.patch('mysite.search.models.Project.populate_icon_from_ohloh')
-    @mock.patch('mysite.search.tasks.PopulateProjectLanguageFromOhloh')
-    def test_post_handler(self, mock_populate_icon, mock_populate_language):
+    def test_post_handler(self):
         # Show that it works
         project_name = 'Something novel'
         self.assertFalse(
@@ -137,10 +135,7 @@ class ProjectPageCreation(TwillTests):
         # of this Project.
         # This could easily be a log for edits.
 
-    @mock.patch('mysite.search.models.Project.populate_icon_from_ohloh')
-    @mock.patch('mysite.search.tasks.PopulateProjectLanguageFromOhloh')
-    def test_project_creator_simply_redirects_to_project_if_it_exists(
-            self, mock_populate_icon, mock_populate_language):
+    def test_project_creator_simply_redirects_to_project_if_it_exists(self):
         # Show that it works
         project_name = 'Something novel'
         Project.create_dummy(name=project_name.lower())

--- a/mysite/search/tasks/__init__.py
+++ b/mysite/search/tasks/__init__.py
@@ -25,45 +25,6 @@ import mysite.base.view_helpers
 
 logger = logging.getLogger(__name__)
 
-class PopulateProjectIconFromOhloh(Task):
-
-    def run(self, project_id):
-        project = mysite.search.models.Project.objects.get(id=project_id)
-        project.populate_icon_from_ohloh()
-        project.save()
-
-
-class PopulateProjectLanguageFromOhloh(Task):
-
-    def run(self, project_id, **kwargs):
-        logger = self.get_logger(**kwargs)
-        p = mysite.search.models.Project.objects.get(id=project_id)
-        if not p.language:
-            oh = mysite.customs.ohloh.get_ohloh()
-            try:
-                raise KeyError  # NOTE: This is known to be broken.
-                # It used to call this:
-                # analysis_id = oh.get_latest_project_analysis_id(p.name)
-                # but the we removed the get_latest_project_analysis_id
-                # method.
-            except KeyError:
-                logger.info("No Ohloh analysis found -- early %s" %
-                            p.name)
-                return
-            try:
-                data, _ = oh.analysis_id2analysis_data(analysis_id)
-            except KeyError:
-                logger.info("No Ohloh analysis found for %s" %
-                            p.name)
-                return
-            if ('main_language_name' in data and
-                    data['main_language_name']):
-                # re-get to minimize race condition time
-                p = mysite.search.models.Project.objects.get(id=project_id)
-                p.language = data['main_language_name']
-                p.save()
-                logger.info("Set %s.language to %s" %
-                            (p.name, p.language))
 
 # Right now, we cache /search/ pages to disk. We should throw those away
 # under two circumstances.

--- a/mysite/search/tests.py
+++ b/mysite/search/tests.py
@@ -764,8 +764,7 @@ class QueryGetToughnessFacetOptions(SearchTest):
 
 class QueryGetPossibleLanguageFacetOptionNames(SearchTest):
 
-    @mock.patch('mysite.search.tasks.PopulateProjectLanguageFromOhloh')
-    def setUp(self, do_nothing):
+    def setUp(self):
         SearchTest.setUp(self)
         python_project = Project.create_dummy(language=u'Python')
         perl_project = Project.create_dummy(language=u'Perl')
@@ -835,8 +834,7 @@ class QueryGetPossibleLanguageFacetOptionNames(SearchTest):
 
 class QueryGetPossibleProjectFacetOptions(SearchTest):
 
-    @mock.patch('mysite.search.tasks.PopulateProjectLanguageFromOhloh')
-    def setUp(self, do_nothing):
+    def setUp(self):
         SearchTest.setUp(self)
         projects = [
             Project.create_dummy(name=u'Miro'),


### PR DESCRIPTION
Hi!

I removed PopulateProjectIconFromOhloh and PopulateProjectLanguageFromOhloh as well as their corresponding tests as discussed in https://github.com/openhatch/oh-mainline/issues/1462.

I ran the whole test suite before and after making these changes, and all of the tests passed on my system.

Thanks to @willingc for her guidance and encouragement! : - )

Thanks & regards,
Eeshan Garg
