### PR TITLE
query created_date instead of modified_date for recent activity

### DIFF
--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -46,9 +46,9 @@ def front_page_data():
     data = {}
     data['entries'] = mysite.customs.feed.cached_blog_entries()[:1]
     feed_items = list(
-        mysite.search.models.Answer.objects.order_by('-modified_date')[:5])
+        mysite.search.models.Answer.objects.order_by('-created_date')[:5])
     feed_items.extend(
-        mysite.search.models.WannaHelperNote.objects.order_by('-modified_date')[:5])
+        mysite.search.models.WannaHelperNote.objects.order_by('-created_date')[:5])
     feed_items.sort(key=lambda x: x.modified_date, reverse=True)
     data['recent_feed_items'] = feed_items[:5]
     return data


### PR DESCRIPTION
fix issue #1367
