### PR TITLE
Fix typo in vendor/django-debug-toolbar

### DIFF
--- a/vendor/packages/django-debug-toolbar/debug_toolbar/utils.py
+++ b/vendor/packages/django-debug-toolbar/debug_toolbar/utils.py
@@ -33,7 +33,7 @@ def get_module_path(module_name):
     else:
         source_path = inspect.getsourcefile(module)
         # Note that source_path is a byte string in the default
-        # encoding for the filesystem, which meands that
+        # encoding for the filesystem, which means that
         # calling .endswith() will attempt to convert it to
         # ASCII.
         #


### PR DESCRIPTION
Typo was introduced in
https://github.com/openhatch/oh-mainline/commit/e641408564fb9dde26083d510fb0a9ac591a1251
by @paulproteus.
