### PR TITLE
fix for #1443

### DIFF
--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -47,8 +47,23 @@ import mysite.missions.setup.views
 
 from mysite.base.feeds import RecentActivityFeed
 
-
-urlpatterns = patterns('',
+# Return a robots.txt that disallows all spiders when DEBUG is True  
+if getattr(settings, "DEBUG", True):
+    urlpatterns = patterns('', 
+                    (r'^robots.txt$', 
+                     lambda x: HttpResponse("User-agent: *\nDisallow: /", 
+                                            content_type = "text/plain")
+                     )
+                    )
+else:
+    urlpatterns = patterns('', 
+                    (r'^robots.txt$', 
+                    lambda x: HttpResponse("User-agent: *\nDisallow: ", 
+                                           content_type = "text/plain")
+                     )
+                    )
+    
+urlpatterns += patterns('',
                        # Okay, sometimes people link /, or /) because of bad linkification
                        # if so, just permit it as a redirect.
                        (r'^,$', lambda x: HttpResponsePermanentRedirect('/')),


### PR DESCRIPTION
The urlpatterns in mysite/urls.py will have a pattern for robots.txt.
This pattern will have the Disallow directive set to / if settings.DEBUG
is True. Else, it will be set to an empty string. We need a test for
this. I would like to do it if you can help me with it. I referenced
this code
https://github.com/stephenmcd/mezzanine/blob/master/mezzanine/urls.py
while writing this fix.