### PR TITLE
Update testing basics doc and add helper tool to run tests without warnings

### DIFF
--- a/docs/getting_started/testing_basics.rst
+++ b/docs/getting_started/testing_basics.rst
@@ -20,6 +20,18 @@ The test suite begin running all of the tests and will display the test
 progress in the console window.
 
 
+Running the test suite without warnings
+#######################################
+
+You may run the test suite and turn off warnings, such as Deprecation Warnings, 
+being output to your screen. To run the test suite without warnings,::
+
+    python -Wignore manage.py test
+
+The test suite will display its progress on the console but will not display
+any warnings.
+
+
 Running a subset of tests
 #########################
 

--- a/tools/run_tests_nowarn.py
+++ b/tools/run_tests_nowarn.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""Run oh-mainline tests ignoring warnings"""
+
+import os
+
+os.system("python -Wignore manage.py test")


### PR DESCRIPTION
In Python 2.7.6, deprecation warnings were quieted by default. In Django 1.5, deprecation warnings are passed to the console by default overiding Python's default behavior. It would be nice to explain to the user how to run the tests without deprecation warnings.

A section has been added to the testing basics documentation page. 

A simple helper tool to run test suite without warnings has been added as a convenience for developers.
