### PR TITLE
Fix minor formatting error in testing basics doc

### DIFF
--- a/docs/getting_started/testing_basics.rst
+++ b/docs/getting_started/testing_basics.rst
@@ -23,8 +23,9 @@ progress in the console window.
 Running the test suite without warnings
 #######################################
 
-You may run the test suite and turn off warnings, such as Deprecation Warnings, 
-being output to your screen. To run the test suite without warnings,::
+You may run the test suite and turn off warnings, such as "deprecation
+warnings", being output to your screen. To run the test suite without
+warnings,::
 
     python -Wignore manage.py test
 


### PR DESCRIPTION
This fixes a small error in documentation style.

Thanks to @ehashman for pointing out a better style in PR #1490. The suggestion is a good one, so here's the fix :)
