### PR TITLE
Remove location submit field from /people, remove un-used html tags on search_people.html

### DIFF
--- a/mysite/base/templates/nextsteps4helpers.html
+++ b/mysite/base/templates/nextsteps4helpers.html
@@ -75,7 +75,7 @@
                         {% include 'profile/person-summary-li.html' %}
                     {% endwith %}
                 </ul>
-                <p class='rabbit_hole'><a href='{% url "mysite.profile.views.people" %}?center={{user.get_profile.location_display_name}}'>Find people near you &raquo;</a></p>
+                <p class='rabbit_hole'><a href='{% url "mysite.profile.views.people" %}'>Find people near you &raquo;</a></p>
             </div>
         </div>
     </div>
@@ -95,7 +95,7 @@
                         {% include 'profile/person-summary-li.html' %}
                     {% endwith %}
                 </ul>
-                <p class='rabbit_hole'><a href='{% url "mysite.profile.views.people" %}?center={{user.get_profile.location_display_name}}'>Find people near you &raquo;</a></p>
+                <p class='rabbit_hole'><a href='{% url "mysite.profile.views.people" %}'>Find people near you &raquo;</a></p>
             </div>
         </div>
     </div>

--- a/mysite/profile/templates/profile/search_people.html
+++ b/mysite/profile/templates/profile/search_people.html
@@ -47,7 +47,7 @@ People Search
             <div class='submit field'>
               <div class="input-and-labels">
                 <label for='search_locations'>&nbsp;</label>
-                <input type="submit" value="Search"/>
+                <input type="submit" value="Search"/> 
               </div>
             </div>
         </div>


### PR DESCRIPTION
When users try to search people based on location, the results are always zero. There are no results for location-based people search. That is because the geo-location feature has been removed and is no longer supported. This PR removes the location box from the /people/ page to avoid this confusion. 

BEFORE:
![people_search_before](https://cloud.githubusercontent.com/assets/954858/5356026/9272b204-7f4d-11e4-9081-3f0c52295086.png)

AFTER:
![people_new](https://cloud.githubusercontent.com/assets/954858/5356033/a1559b56-7f4d-11e4-99e2-cc1f464511c3.png)
