### PR TITLE
Fix issue 1399 to update deployment settings for svn mission

### DIFF
--- a/mysite/deployment_settings.py
+++ b/mysite/deployment_settings.py
@@ -47,6 +47,8 @@ CACHE_BACKEND = "memcached://linode.openhatch.org:11211/?timeout=1"
 
 GOOGLE_ANALYTICS_CODE = 'UA-15096810-1'
 
+# svn mission requires a subdomain svn-mission for cloudflare to
+# work properly
 SVN_REPO_URL_PREFIX = 'svn://svn-mission.openhatch.org/'
 GIT_REPO_URL_PREFIX = 'https://openhatch.org/git-mission-data/git/'
 # Share cookies with subdomain (necessary for Vanilla)
@@ -63,7 +65,8 @@ import logging
 logger = logging.getLogger('')
 logger.setLevel(logging.WARNING)
 
-ALLOWED_HOSTS=['testserver', 'openhatch.org']
+# svn-mission subdomain needed in ALLOWED_HOSTS due to cloudflare
+ALLOWED_HOSTS=['testserver', 'openhatch.org', 'svn-mission.openhatch.org']
 
 # This means that, when we run 'python manage.py collectstatic'
 # on the deployment, that they go in the path below.


### PR DESCRIPTION
The svn mission has been generating 500 errors when a user tries to submit a diff. I believe that adding the svn-mission subdomain to ALLOWED_HOSTS may solve these issues. 
## Reasoning

A subdomain, svnadmin.openhatch.org, to the deployment_settings file so that the svn
mission would continue to work after adding CloudFlare service.
https://github.com/openhatch/oh-mainline/commit/e7ac7b7aab48162686ede7ae74e4ad3ec0e5b070

The svn repo prefix would now include the subdomain svn-mission
SVN_REPO_URL_PREFIX = 'svn://svn-mission.openhatch.org/'

As part of the migration to version 1.5, ALLOWED_HOSTS was set.
https://github.com/openhatch/oh-mainline/commit/e6a78168bfa27dbca07940c9eb7fb9a792850cf5

I believe that the 500 error may be solved by adding the subdomain svn-mission to the
ALLOWED_HOSTS setting.
