### PR TITLE
Move front-page-specific CSS rules to landing.less

### DIFF
--- a/mysite/static/less/base/base.less
+++ b/mysite/static/less/base/base.less
@@ -298,10 +298,11 @@ img.right { float: right; padding: 0 0 @standard-padding 10px;}
 }
 .aka {
 }
+/* Columns in general float left, and have some margin-right to
+   create visual spacing. */
 .column {
     float: left;
-    margin-left: -1px;
-    width:32%;
+    margin-right: 10px;
 }
 h4, .cute-header {
     font-size: 9pt;

--- a/mysite/static/less/base/landing.less
+++ b/mysite/static/less/base/landing.less
@@ -2,6 +2,13 @@
 
 body#landing {
 
+    /* The columns on the front page take up about one-third
+       of the width. Later rules for responding to browser
+       width changes will adjust these rules further. */
+    .column {
+        margin-left: -1px;
+        width:32%;
+    }
     #landing-module {
         background: @emphasized-module-interior;
         #landing-message {


### PR DESCRIPTION
This partially reverts 98331703bc6cf5ecec711575a5e44c5f39b8d51e

Close #1512

(Note that I could only reproduce #1512 in Firefox, not in
Chromium.)