### PR TITLE
Remove remaining simplejson (deprecated) references

### DIFF
--- a/mysite/base/decorators.py
+++ b/mysite/base/decorators.py
@@ -22,7 +22,7 @@ from django.http import HttpResponse
 import re
 import collections
 import mysite.base.view_helpers
-from django.utils import simplejson
+import json
 import django.core.cache
 import hashlib
 from functools import partial
@@ -184,7 +184,7 @@ def cache_method(cache_key_getter_name, func, *args, **kwargs):
         # First transform certain objects into a cachable format.
         if type(value) == django.db.models.query.ValuesListQuerySet:
             value = list(value)
-        cached_json = simplejson.dumps({'value': value})
+        cached_json = json.dumps({'value': value})
 
         # Then cache the input/output mapping.
         django.core.cache.cache.set(cache_key, cached_json, 864000)
@@ -193,7 +193,7 @@ def cache_method(cache_key_getter_name, func, *args, **kwargs):
     else:
         # Sweet, no need to run the expensive method. Just use the cached
         # output.
-        value = simplejson.loads(cached_json)['value']
+        value = json.loads(cached_json)['value']
 
     return value
 

--- a/mysite/base/view_helpers.py
+++ b/mysite/base/view_helpers.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.utils import simplejson, http
+from django.utils import http
 import urllib
 import os
 import os.path
@@ -34,8 +34,8 @@ import django.conf
 
 
 def json_response(python_object):
-    json = simplejson.dumps(python_object)
-    return HttpResponse(json, mimetype="application/json")
+    json_from_object = json.dumps(python_object)
+    return HttpResponse(json_from_object, mimetype="application/json")
 
 
 class ObjectFromDict(object):
@@ -176,7 +176,7 @@ def get_object_or_none(klass, *args, **kwargs):
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import mysite.base.disk_cache
-from django.utils import simplejson
+import json
 from django.core.cache import cache
 from django.conf import settings
 import hashlib
@@ -305,7 +305,7 @@ def _geocode(address=None, response_data=None):
 
 
 def object_to_key(python_thing):
-    as_string = simplejson.dumps(python_thing)
+    as_string = json.dumps(python_thing)
     return hashlib.sha1(as_string).hexdigest()
 
 
@@ -331,7 +331,7 @@ def cached_geocoding_in_json(address):
         geocoded = _geocode(address) or {}
         geocoded_and_inaccessible = {'is_inaccessible': is_inaccessible}
         geocoded_and_inaccessible.update(geocoded)
-        geocoded_in_json = simplejson.dumps(geocoded_and_inaccessible)
+        geocoded_in_json = json.dumps(geocoded_and_inaccessible)
         if geocoded:
             # cache for a week, which should be plenty
             cache_duration = A_LONG_TIME_IN_SECONDS + \

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -21,7 +21,7 @@
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from mysite.base.view_helpers import render_response
-from django.utils import simplejson
+import json
 from django.template import loader, Context
 
 import mysite.account
@@ -119,7 +119,7 @@ def page_to_js(request):
     # from django.template.loader import render_to_string
     # to generate html_doc
     html_doc = "<strong>zomg</strong>"
-    encoded_for_js = simplejson.dumps(html_doc)
+    encoded_for_js = json.dumps(html_doc)
     # Note: using application/javascript as suggested by
     # http://www.ietf.org/rfc/rfc4329.txt
     return render_response(request, 'base/append_ourselves.js',

--- a/mysite/customs/management/commands/import_bugimporter_data.py
+++ b/mysite/customs/management/commands/import_bugimporter_data.py
@@ -17,7 +17,7 @@
 from django.core.management.base import BaseCommand
 import mysite.customs.core_bugimporters
 import yaml
-from django.utils import simplejson
+import json
 import logging
 
 
@@ -26,9 +26,9 @@ def jsonlines_decoder(f):
         if line.endswith('\n'):
             line = line[:-1]
         try:
-            yield simplejson.loads(line)
+            yield json.loads(line)
         except Exception:
-            logging.exception("simplejson decode failed")
+            logging.exception("json decode failed")
             logging.error("repr(line) was: %s", repr(line))
             continue
 
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         for filename in args:
             with open(filename) as f:
                 if filename.endswith('.json'):
-                    bug_dicts = simplejson.load(f)
+                    bug_dicts = json.load(f)
                 elif filename.endswith('.jsonlines'):
                     bug_dicts = jsonlines_decoder(f)
                 else:

--- a/mysite/missions/base/views.py
+++ b/mysite/missions/base/views.py
@@ -38,7 +38,7 @@ import django.views.generic.edit
 import django.conf
 
 import os
-from django.utils import simplejson
+import json
 import collections
 
 # Other missions use this helper.

--- a/mysite/missions/svn/views.py
+++ b/mysite/missions/svn/views.py
@@ -22,6 +22,7 @@ from mysite.missions.svn import forms, view_helpers
 import mysite.missions.base.views
 import shutil
 import tempfile
+import json
 from django.shortcuts import render
 
 # POST handlers
@@ -177,4 +178,4 @@ class Commit(SvnBaseView):
 
 @login_required
 def commit_poll(request):
-    return HttpResponse(simplejson.dumps(view_helpers.mission_completed(request.user.get_profile(), 'svn_commit')))
+    return HttpResponse(json.dumps(view_helpers.mission_completed(request.user.get_profile(), 'svn_commit')))

--- a/mysite/profile/view_helpers.py
+++ b/mysite/profile/view_helpers.py
@@ -28,7 +28,7 @@ from django.core.cache import cache
 from django.db.models import Q
 import django.core.mail
 import django.core.serializers
-from django.utils import simplejson
+import json
 
 import logging
 import mysite.search.view_helpers
@@ -192,7 +192,7 @@ def send_user_export_to_admins(u):
     * training an antispam tool
 
     * recovering data on a user'''
-    body = simplejson.dumps(generate_user_export(u), default=encode_datetime)
+    body = json.dumps(generate_user_export(u), default=encode_datetime)
     msg = django.core.mail.EmailMessage(subject="User export for %d" % u.id,
                                         body=body,
                                         to=[email

--- a/mysite/profile/views.py
+++ b/mysite/profile/views.py
@@ -24,7 +24,7 @@
 import StringIO
 import datetime
 import urllib
-from django.utils import simplejson
+import json
 import re
 import collections
 import logging
@@ -102,8 +102,8 @@ def add_citation_manually_do(request):
         citation.is_published = True
         citation.save()
 
-        json = simplejson.dumps(output)
-        return HttpResponse(json, mimetype='application/json')
+        json_from_object = json.dumps(output)
+        return HttpResponse(json_from_object, mimetype='application/json')
 
     else:
         error_msgs = []
@@ -111,8 +111,8 @@ def add_citation_manually_do(request):
             error_msgs.extend(eval(error.__repr__()))  # don't ask questions.
 
         output['error_msgs'] = error_msgs
-        json = simplejson.dumps(output)
-        return HttpResponseServerError(json, mimetype='application/json')
+        json_from_object = json.dumps(output)
+        return HttpResponseServerError(json_from_object, mimetype='application/json')
 
     #}}}
 
@@ -208,7 +208,7 @@ def widget_display_js(request, user_to_display__username):
     # FIXME: In the future, use:
     html_doc = widget_display_string(request, user_to_display__username)
     # to generate html_doc
-    encoded_for_js = simplejson.dumps(html_doc)
+    encoded_for_js = json.dumps(html_doc)
     # Note: using application/javascript as suggested by
     # http://www.ietf.org/rfc/rfc4329.txt
     return render_response(request, 'base/append_ourselves.js',
@@ -506,21 +506,21 @@ def gimme_json_for_portfolio(request):
 
     five_minutes_ago = datetime.datetime.utcnow() - \
         datetime.timedelta(minutes=5)
-    portfolio_entries = simplejson.loads(serializers.serialize('json',
+    portfolio_entries = json.loads(serializers.serialize('json',
                                                                portfolio_entries_unserialized))
-    projects = simplejson.loads(
+    projects = json.loads(
         serializers.serialize('json', projects_unserialized))
     # FIXME: Don't send like all the flippin projects down the tubes.
-    citations = simplejson.loads(serializers.serialize('json', citations))
+    citations = json.loads(serializers.serialize('json', citations))
 
-    json = simplejson.dumps({
+    portfolio_json = json.dumps({
         'citations': citations,
         'portfolio_entries': portfolio_entries,
         'projects': projects,
         'summaries': summaries,
     })
 
-    return HttpResponse(json, mimetype='application/json')
+    return HttpResponse(portfolio_json, mimetype='application/json')
 
 
 def replace_icon_with_default(request):

--- a/mysite/search/tests.py
+++ b/mysite/search/tests.py
@@ -35,7 +35,8 @@ from django.utils.unittest import skipIf
 import django.db
 import django.conf
 
-from django.utils import simplejson, http
+from django.utils import http
+import json
 import mock
 from twill import commands as tc
 
@@ -203,7 +204,7 @@ class SearchResults(TwillTests):
         self.assert_(json_string_with_parens[0] == u'(')
         self.assert_(json_string_with_parens[-1] == u')')
         json_string = json_string_with_parens[1:-1]
-        objects = simplejson.loads(json_string)
+        objects = json.loads(json_string)
         self.assert_(u'pk' in objects[0][u'bugs'][0])
 
     @skipIf(django.db.connection.vendor == 'sqlite',

--- a/mysite/search/views.py
+++ b/mysite/search/views.py
@@ -33,7 +33,8 @@ from mysite.base.view_helpers import render_response
 import datetime
 from dateutil import tz
 import pytz
-from django.utils import simplejson, http
+from django.utils import http
+import json
 import mysite.search.forms
 import mysite.base.decorators
 
@@ -204,7 +205,7 @@ def bugs_to_json_response(data, bunch_of_bugs, callback_function_name=''):
     data_list = [{'bugs': bugs}]
 
     # Step 4: Create the string form of the JSON
-    json_as_string = simplejson.dumps(data_list, default=encode_datetime)
+    json_as_string = json.dumps(data_list, default=encode_datetime)
 
     # Step 5: Prefix it with the desired callback function name
     json_string_with_callback = callback_function_name + \


### PR DESCRIPTION
Remove remaining simplejson references in the files of the mysite directory. simplejson was deprecated in Django 1.5. The Python json module should be used going forward.
https://docs.djangoproject.com/en/1.7/releases/1.5/#django-utils-simplejson

