### PR TITLE
Update docs on Continuous Integration #1428

### DIFF
--- a/docs/getting_started/handling_contributions.rst
+++ b/docs/getting_started/handling_contributions.rst
@@ -138,7 +138,7 @@ person to do this, but it's good to ask someone else so they get practice!
 
 Things to know:
 
-    * If you push to origin/master, Jenkins will test it.
+    * If you push to origin/master, Travis CI will test it.
     * Once you're happy, you can run the deploy script, but note that will push
       the current HEAD to origin/master. ::
 
@@ -148,7 +148,7 @@ Things to know:
 
     * When you deploy, check a page or two to make sure things are okay.
 
-For more details on how we use Jenkins and how to force a Jenkins build, see
-`Continuous integration with Jenkins and Travis CI`_.
+For more details on how we use Continuous Integration and Travis CI, see
+`Continuous integration`_.
 
-.. _Continuous integration with Jenkins and Travis CI: ../internals/continuous_integration.html
+.. _Continuous integration: ../internals/continuous_integration.html

--- a/docs/internals/continuous_integration.rst
+++ b/docs/internals/continuous_integration.rst
@@ -1,42 +1,80 @@
-=================================================
-Continuous Integration with Jenkins and Travis CI
-=================================================
+======================
+Continuous Integration
+======================
 
 
 Overview
 ========
 
-The OpenHatch code has a suite of tests. It's important that when we deploy the
-code to the website, all tests pass.
+The OpenHatch code has a suite of tests. It's important that when we deploy
+the code changes to the website that all tests are passing.
 
-Jenkins is a "continuous integration" tool (read `more on Wikipedia`_). It wakes
-up once an hour, checks the git repository for new commits, and runs the test
-suite. For additional information about Jenkins, read `more on Jenkins`_.
+`Continuous integration`_ helps our developers see if their code changes are
+passing all tests or are failing a test and additional code changes are
+needed.
+
+.. _Continuous integration: http://www.aosabook.org/en/integration.html
+
+
+Travis CI
+=========
+
+`Travis CI`_ is a hosted, distributed "continuous integration" system (read
+`more on Wikipedia about Travis CI`_). The GitHub page for the `oh-mainline`
+indicates whether our tests currently are passing.
+
+.. _more on Wikipedia about Travis CI: https://en.wikipedia.org/wiki/Travis_CI
+.. _Travis CI: https://travis-ci.org
+
+Using Travis CI
+---------------
+There are multiple ways that Travis CI communicates the source code's current
+build status and whether tests are passing:
+
+* The first is the "build" badge on the `oh-mainline` GitHub page displayed
+  at the top of the README. Clicking on the "build" badge will display
+  Travis CI's status page for OpenHatch.
+
+* OpenHatch's Travis CI status page can be directly found at
+  `<https://travis-ci.org/openhatch/oh-mainline>`_.
+
+* GitHub also provides information on every pull request about Travis CI's
+  testing and status related to the individual pull request. This is very
+  helpful for developers and reviewers.
+
+
+  .. note:: Currently, Travis CI is showing that our tests are not passing
+            when tested with a MySQL database. Details can be found in the
+            OpenHatch issue tracker. We hope to have this issue resolved soon.
+
+
+Configuration for Travis CI
+---------------------------
+
+The `.travis.yml` file in the `oh-mainline` directory contains configuration
+information used by Travis CI.
+
+
+Jenkins
+=======
+
+Jenkins is a "continuous integration" tool (read `more on Wikipedia`_). It
+wakes up once an hour, checks the git repository for new commits, and runs the
+test suite. For additional information about Jenkins, read `more on Jenkins`_.
 
 .. _more on Wikipedia: https://en.wikipedia.org/wiki/Continuous_integration
 .. _more on Jenkins: https://jenkins-ci.org
 
-Travis CI is a hosted, distributed "continuous integration" system (read 
-`more on Wikipedia about Travis CI`_). For additional information about 
-Travis CI, read `more on Travis CI`_.
-
-.. _more on Wikipedia about Travis CI: https://en.wikipedia.org/wiki/Travis_CI
-.. _more on Travis CI: https://travis-ci.org
-
-
-Jenkins Dashboard for OpenHatch
-===============================
 
 Status information about continuous integration projects can be found on 
 OpenHatch's Jenkins dashboard : http://vm3.openhatch.org
 
 
-Configuration
-=============
-
-There are a number of "projects" in Jenkins. Different ones run different suites of
-tests in the OpenHatch codebase. They include or exclude different Django apps
-from the OpenHatch codebase.
+Jenkins configuration
+---------------------
+There are a number of "projects" in Jenkins. Different ones run different
+suites of tests in the OpenHatch codebase. They include or exclude different
+Django apps from the OpenHatch codebase.
 
 For example,
 
@@ -58,20 +96,11 @@ For example,
 
   - This is the catchall that tests the rest of the code.
 
+Status information about continuous integration projects can be found on
+OpenHatch's Jenkins dashboard.
 
-How to see the list of tests that failed or passed
-==================================================
-
-* Go to http://vm3.openhatch.org
-* Choose a project (for example, `Test the search app`_)
-* Click on "Latest Test Result"
-
-
-.. _Test the search app: http://vm3.openhatch.org/job/Test%20the%20%22search%22%20app/
-
-
-Permissions
-===========
+Jenkins administration
+----------------------
 
 Right now, only Raffi and Asheesh can modify the configuration of Jenkins.
 
@@ -79,25 +108,11 @@ Anyone can enqueue a run of the test suite by clicking a "Build" link within
 a Jenkins project. That's a good thing.
 
 
-IRC
-===
-
-It hangs out on #openhatch as openhatch_hudson. Type !hudsonhelp to find out the
-bot's commands.
-
-
-Configuration for Travis CI
-===========================
-
-The `.travis.yml` file in the `oh-mainline` directory contains configuration
-information used by Travis CI.
-
-
 Future work
 ===========
 
-It would be super nice if, whenever there was a commit to Github master that
-passed all the tests, Jenkins automatically deployed it.
+It would be super nice if, whenever there was a commit to GitHub master that
+passed all the tests, it would be automatically deployed.
 
 
 .. _Bug filed: https://openhatch.org/bugs/issue173


### PR DESCRIPTION
This Pull Request updates the Travis CI and Continuous Integration docs. Testing Basics documentation updated for consistency.

Updates Continuous Integration to refer to the very well done overview of CI here: http://www.aosabook.org/en/integration.html 

This addresses issue #1428.