### PR TITLE
[Bug #1267] avoid open redirection in register URL 

### DIFF
--- a/mysite/account/tests.py
+++ b/mysite/account/tests.py
@@ -451,3 +451,27 @@ class ClearSessionsOnPasswordChange(WebTest):
 
         self.assertTrue(self.user_logged_in(client1.session))
         self.assertFalse(self.user_logged_in(client2.session))
+
+class UrlRedirect(WebTest):
+    fixtures = ['user-paulproteus']
+
+    def test_appended_url_redirect(self):
+        client = Client()
+        username = 'paulproteus'
+        password = "paulproteus's unbreakable password"
+        client.login(username=username, password=password)
+
+        # All test cases should redirect to the OpenHatch root.
+        response = client.get('/openid/register/?next=/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/')
+
+        # Verify appended redirect url is ignored:
+        response = client.get('/openid/register/?next=http://www.example.com')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/')
+
+        # Verify appended redirect url is ignored
+        response = client.get('/account/logout/?next=http:///www.example.com')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/')

--- a/mysite/account/views.py
+++ b/mysite/account/views.py
@@ -42,7 +42,7 @@ import mysite.profile.views
 # FIXME: We did this because this decorator used to live here
 # and lots of other modules refer to it as mysite.account.views.view.
 # Let's fix this soon.
-from mysite.base.decorators import view
+from mysite.base.decorators import view, authenticated
 import django.contrib.auth.views
 
 logger = logging.getLogger(__name__)
@@ -413,7 +413,7 @@ def invite_someone_do(request):
 # modified trivially in the POST handler.
 
 
-@django_authopenid.views.not_authenticated
+@authenticated
 def register(request,
              template_name='authopenid/complete.html',
              redirect_field_name=django.contrib.auth.REDIRECT_FIELD_NAME,
@@ -530,7 +530,6 @@ def register(request,
     }, context_instance=django_authopenid.views._build_context(
         request, extra_context=extra_context))
 
-# We use this "not_authenticated" wrapper so that if you *are* logged in,
+# We use this "authenticated" wrapper so that if you *are* logged in,
 # you go straight to the ?next= value.
-login = django_authopenid.views.not_authenticated(
-    django.contrib.auth.views.login)
+login = authenticated(django.contrib.auth.views.login)

--- a/mysite/base/decorators.py
+++ b/mysite/base/decorators.py
@@ -18,7 +18,7 @@
 from decorator import decorator
 from odict import odict
 import logging
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 import re
 import collections
 import mysite.base.view_helpers
@@ -26,6 +26,7 @@ from django.utils import simplejson
 import django.core.cache
 import hashlib
 from functools import partial
+from urlparse import urlparse
 
 from django.template.loader import render_to_string
 import django.db.models.query
@@ -213,3 +214,17 @@ def cached_property(f):
             return x
 
     return property(get)
+
+def authenticated(func):
+    """ decorator that redirect user to next page if
+    he is already logged."""
+    def decorated(request, *args, **kwargs):
+        if request.user.is_authenticated():
+            next = request.GET.get("next", "/")
+            parsed_url = urlparse(next)
+            if parsed_url.scheme == '':
+                return HttpResponseRedirect(next)
+            else:
+                return HttpResponseRedirect("/")
+        return func(request, *args, **kwargs)
+    return decorated


### PR DESCRIPTION
This fixes open redirection in `openid/register/`. Earlier `openid/register/?next=http://example.com` redirected user to `example.com` now it redirects to OpenHatch root. Also included tests for the same.