### PR TITLE
Use AJAX for image upload and show a progess bar: Issue #560

### DIFF
--- a/mysite/account/templates/account/edit_photo.html
+++ b/mysite/account/templates/account/edit_photo.html
@@ -25,6 +25,14 @@
 {% block body_class%}{{ block.super }} auth{% endblock %}
 
 {% block main %}
+<!--Include script for Ajax image upload-->
+    <script type="text/javascript" src="/static/js/account/edit_photo.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            set_callback_for_image_upload("{{ csrf_token }}"); 
+        });
+
+    </script>
     <div class='module'>
         <div class='module-head'>
             <ul>
@@ -40,12 +48,20 @@
                     <h3>Current profile photo</h3>
                 </div>
                 <div class='submodule-body'>
-                    <img src="{{ photo_url }}" />
+                    <img id="profileimage" src="{{ photo_url }}" />
                 </div>
             </div>
             <div class="submodule photo-wide">
+            <div class="notification" id="notification">
+                <div id="notification_message"></div>
+                <div class="clearbutton">
+                    <a id="clear_message" href="?">(clear this message)</a>
+                </div>
+            </div>
+
             <form method='POST'
                     name='edit_photo'
+                    id='edit_photo' 
                     action='/account/edit/photo/do'
                     enctype="multipart/form-data">{% csrf_token %}
                 <div class='head'>
@@ -53,6 +69,7 @@
                 </div>
                 <div class='body'>
 		    {% if non_validation_error %}
+
 		    <ul class="errorlist">
 		      <li>
 			Oops! Something went wrong while preparing this
@@ -74,6 +91,7 @@
                     <input type="submit" value="Upload">
                 </div>
             </form>
+            <div id="progressBar" class="default" style="display:none;"><div></div></div>
             </div>
     </div>
     <div class="module-foot">

--- a/mysite/account/views.py
+++ b/mysite/account/views.py
@@ -123,12 +123,9 @@ def edit_photo_do(request, mock=None):
     if valid:
         person = form.save()
         person.generate_thumbnail_from_photo()
-
-        return HttpResponseRedirect(
-            reverse(mysite.profile.views.display_person_web,
-                    kwargs={'user_to_display__username': request.user.username
-                    })
-        )
+        url = person.get_photo_url_or_default()
+        # Removing the Redirect since it doesn't make sense in an AJAX context
+        return HttpResponse(url, mimetype="text/plain")
     else:
         return edit_photo(request, form)
 

--- a/mysite/static/css/account/settings.css
+++ b/mysite/static/css/account/settings.css
@@ -2,3 +2,24 @@ body.settings,body.missions .submodule.skinny { padding: 0 ! important; border: 
 body.settings,body.missions .submodule.skinny .body { padding: 10px ! important; background-color: transparent ! important; }
 body.settings,body.missions .submodule.skinny ul li { margin-bottom: 10px; font-size: 11pt; }
 body.settings,body.missions #main .submodule .body { background-color: #fff; padding: 3% 5%; }
+.default {
+    background: #292929;
+    border: 1px solid #111; 
+    border-radius: 5px; 
+    overflow: hidden;
+    width: 20%;
+    box-shadow: 0 0 5px #333;               
+}
+.default div {
+    background-color: #FF6D3D;
+    width: 0%
+}
+
+#notification {
+	display: none;
+}
+
+.clearbutton {
+	float: right;
+	display: inline;
+}

--- a/mysite/static/js/account/edit_photo.js
+++ b/mysite/static/js/account/edit_photo.js
@@ -1,0 +1,64 @@
+var csrf_token = null;
+var width = null;
+
+function set_callback_for_image_upload(token){
+    $("#edit_photo").on("submit", upload_image);
+    csrf_token = token;
+    width = $("#progressBar").width();
+    $('#clear_message').on("click", hide_notification);
+}
+
+function hide_notification(event){
+    $("#notification").hide();
+    return false;
+}
+
+function update(evt){
+    $("#progressBar").css("display", "");
+    var percent = Math.floor(evt.loaded/evt.total * 100);
+    var progressBarWidth = Math.floor((percent * width) / 100);
+    $("#progressBar").find('div').animate({ width: progressBarWidth }, 500).html(percent + "%&nbsp;");
+}
+
+function upload_image(event){
+    $("#progressBar").find("div").css("width", "0px");
+    event = event || window.event;
+    // Prevent the default form action i.e. loading of a new page
+    if(event.preventDefault){ // W3C Variant
+        event.preventDefault();
+    }
+    else{ // IE < 9
+        event.returnValue = false;
+    }
+    $.ajax({
+            url: "/account/edit/photo/do",
+            type: "POST",
+            data: new FormData($('#edit_photo')[0]), 
+
+            success : function(data){
+                $("#notification_message").html("Image Saved Successfully");
+                $("#notification").css("display", "block");
+                $("#progressBar").find("div").css("width", "0px");
+                $("#progressBar").css("display", "none");
+                $("#profileimage").attr("src", data);
+            },
+
+            xhr: function(){
+                // get the native XmlHttpRequest object
+                var xhr = $.ajaxSettings.xhr() ;
+                // set the onprogress event handler
+                xhr.upload.onprogress = update,
+                // set the onload event handler
+                xhr.upload.onload = function(){ } ;
+                // return the customized object
+                return xhr ;
+            },
+
+            enctype: 'multipart/form-data',
+            processData: false,
+            contentType: false,
+            cache: false,
+            headers: { "X-CSRFToken": csrf_token }
+    });
+}
+    


### PR DESCRIPTION
Hi @paulproteus @ehashman  @willingc @shaunagm ,

I've modified the "Edit your Profile Image" flow to use AJAX; The progress is reported in a callback in which the progress bar is updated. Here's what it looks like:
![screenshot from 2015-02-08 16 40 31](https://cloud.githubusercontent.com/assets/3866405/6096339/85dcd404-afb1-11e4-8775-a56dcb74f421.png)

I've removed the HttpResponseRedirect in the edit_photo_do view and have instead returned a plain text message. The notification pops up on completion of the upload:
![screenshot from 2015-02-08 16 40 35](https://cloud.githubusercontent.com/assets/3866405/6096342/c61c2aa6-afb1-11e4-90cd-744555e66761.png)

I've tested it on the versions of Chrome and Firefox I use and it seems to work fine. Please do let me know what you think, and if you want the color/position of the progress bar to be changed in any way. While testing these changes locally, please do use an image of about 3-4 MB :)

This resolves Issue #560.

Thanks :)