### PR TITLE
Add ALT text to images on homepage

### DIFF
--- a/mysite/base/templates/base/answer-in-feed.html
+++ b/mysite/base/templates/base/answer-in-feed.html
@@ -27,10 +27,10 @@ OMG inline styles every-freaking-where. WTF. #TODO: FIX!
                     <li style='font-size: .9em; float: left; width: 100%;'>
 		                {% if answer.author %}
                         <a href='{{ answer.author.get_profile.profile_url }}'>
-                            <img style='width: 30px; float: left; margin-right: 10px;' src={% version answer.author.get_profile.get_photo_thumbnail_30px_wide_url_or_default %} />
+                            <img style='width: 30px; float: left; margin-right: 10px;' alt="" src={% version answer.author.get_profile.get_photo_thumbnail_30px_wide_url_or_default %} />
                         </a>
                         {% else %}
-                            <img style='width: 30px; float: left; margin-right: 10px;' src={% version '/static/images/profile-photos/penguin-30px.png' %} >
+                            <img style='width: 30px; float: left; margin-right: 10px;' alt="" src={% version '/static/images/profile-photos/penguin-30px.png' %} >
                         {% endif %}
                         <div style='float: left; width: 80%;'>
                             <span>

--- a/mysite/base/templates/base/wannahelp-in-feed.html
+++ b/mysite/base/templates/base/wannahelp-in-feed.html
@@ -27,7 +27,7 @@
 {% cache 86400 recent_activity_wannahelp_v4 answer.pk %}
 <li style='font-size: .9em; float: left; width: 100%;'>
   <a href='{{ person.profile_url }}'>
-    <img style='width: 30px; float: left; margin-right: 10px;' src='{{ feed_item.person.get_photo_thumbnail_30px_wide_url_or_default }}' />
+    <img style='width: 30px; float: left; margin-right: 10px;' alt="" src='{{ feed_item.person.get_photo_thumbnail_30px_wide_url_or_default }}' />
   </a>
   <div style='float: left; width: 80%;'>
     <span>


### PR DESCRIPTION
See: <https://github.com/openhatch/oh-mainline/issues/1446>

As mentioned in the issue above, much of the ALT portion had already been resolved by another PR earlier. About the redundant links, @paulproteus suggested that if possible, none of the links should be removed and also said something about specifying alt="" to fix this. However, if I'm not mistaken, I think specifying alt="" to fix this will work only if an image and some adjacent text link to the same page, not in the case where some text links to a page and some adjacent text links to that same page; so what should I do about redundant links like these?

Also, the only section of the homepage that needed some work was the "Recent site activity" section. The images of the users had no alt text and the image and adjacent text (the name of the user) both linked to the profile page of the user. So, I added an alt="" for the images in this section which should fix both the "missing alt" issues as well as the redundant links (as mentioned above and according to webaim). :-)

Please let me know if this needs further work, I would love to work on it! :-)

Warm regards,
Eeshan Garg 