### PR TITLE
'Intro to developers' link was broken. Repaired!

### DIFF
--- a/mysite/base/templates/base/base.html
+++ b/mysite/base/templates/base/base.html
@@ -176,7 +176,7 @@
 	      <div class="column">
 		<h3>OpenHatch web app code</h3>
 		<ul>
-		  <li><a href="http://openhatch.readthedocs.org/en/latest/README.html">Intro for developers</a></li>
+		  <li><a href="http://openhatch.readthedocs.org/en/latest">Intro for developers</a></li>
 		  <li><a href="https://github.com/openhatch/oh-mainline">Github (source code)</a></li>
 		  <li><a href="http://lists.openhatch.org/mailman/listinfo/devel">Devel mailing list</a></li>
 		  <li><a href="http://openhatch.readthedocs.org/">Code docs</a></li>


### PR DESCRIPTION
Earlier 'Intro to developers' link (http://openhatch.readthedocs.org/en/latest/README.html) was showing 404 error. The link actually should be 'http://openhatch.readthedocs.org/en/latest'. Made changes.