### PR TITLE
Add language_mentor_count and the required tests toward fix for #890

### DIFF
--- a/mysite/search/models.py
+++ b/mysite/search/models.py
@@ -117,12 +117,40 @@ class Project(OpenHatchModel):
         return self.name
 
     @mysite.base.decorators.cached_property
+    def has_mentors(self):
+        '''Return True if the project has mentors. False, otherwise.
+        '''
+        return  self.mentor_count() > 0
+           
+    @mysite.base.decorators.cached_property
+    def get_mentors_search_url(self):
+        import mysite.profile.view_helpers
+        mentors_available = bool(mysite.profile.view_helpers.TagQuery(
+            'can_mentor', self.name).people)
+        if mentors_available or self.language:
+            query_var = self.name
+            if not mentors_available:
+                query_var = self.language
+            query_string = http.urlencode({u'q': u'can_mentor:"%s"' % query_var})
+            return reverse(mysite.profile.views.people) + '?' + query_string
+        else:
+            return ""
+        
+    @mysite.base.decorators.cached_property
     def mentor_count(self):
         '''Return a number of potential mentors, counted as the number of
          people who can mentor in the project
         '''
         import mysite.profile.view_helpers
         tq = mysite.profile.view_helpers.TagQuery('can_mentor', self.name)
+        return tq.people.count()
+    
+    @mysite.base.decorators.cached_property
+    def language_mentor_count(self):
+        '''Return the number of mentors for the project's programming language
+        '''
+        import mysite.profile.view_helpers
+        tq = mysite.profile.view_helpers.TagQuery('can_mentor', self.language)
         return tq.people.count()
 
     @staticmethod
@@ -325,20 +353,6 @@ class Project(OpenHatchModel):
         import mysite.project.views
         return reverse(mysite.project.views.edit_project,
                        kwargs={'project__name': mysite.base.unicode_sanity.quote(self.name)})
-
-    @mysite.base.decorators.cached_property
-    def get_mentors_search_url(self):
-        import mysite.profile.view_helpers
-        mentors_available = bool(mysite.profile.view_helpers.TagQuery(
-            'can_mentor', self.name).people)
-        if mentors_available or self.language:
-            query_var = self.name
-            if not mentors_available:
-                query_var = self.language
-            query_string = http.urlencode({u'q': u'can_mentor:"%s"' % query_var})
-            return reverse(mysite.profile.views.people) + '?' + query_string
-        else:
-            return ""
 
     def get_bug_count(self):
         if hasattr(self, 'bug_count'):

--- a/mysite/search/templates/search/result.html
+++ b/mysite/search/templates/search/result.html
@@ -35,9 +35,9 @@
 
     {# Mentors #}
     <div class="helpers">
-        {% if bug.project.get_mentors_search_url and bug.project.mentor_count %}
+        {% if bug.project.has_mentors %}
         <a href="{{ bug.project.get_mentors_search_url }}">
-            Mentors: {{ bug.project.mentor_count }} (and {{bug.project.get_language_mentors_count }} in {{ bug.project.language }})</a>
+            Mentors: {{ bug.project.mentor_count }} (and {{ bug.project.language_mentor_count }} in {{ bug.project.language }})</a>
         {% endif %}
     </div>
 

--- a/mysite/search/tests.py
+++ b/mysite/search/tests.py
@@ -1078,10 +1078,10 @@ class PublicizeBugTrackerIndex(SearchTest):
 
 class TestPotentialMentors(TwillTests):
     fixtures = ['user-paulproteus', 'person-paulproteus']
-
-    def test(self):
-        '''Create a Banshee project mentor and verify that the Banshee project
-         has one mentor.'''
+        
+    def test_project_mentor_count(self):
+        '''Create a Banshee with a project mentor and verify that the Banshee 
+        project has one mentor.'''
 
         banshee = Project.create_dummy(name='Banshee', language='C#')
         can_mentor, _ = mysite.profile.models.TagType.objects.get_or_create(
@@ -1098,6 +1098,28 @@ class TestPotentialMentors(TwillTests):
 
         banshee_mentor_count = banshee.mentor_count
         self.assertEqual(1, banshee_mentor_count)
+    
+    def test_project_language_mentor_count(self):
+        '''Create a Banshee project, Add a mentor for C# and verify that the 
+        C# project has one mentor while Banshee has none
+        '''
+
+        banshee = Project.create_dummy(name='Banshee', language='C#')
+        can_mentor, _ = mysite.profile.models.TagType.objects.get_or_create(
+            name=u'can_mentor')
+
+        willing_to_mentor_csharp, _ = (
+            mysite.profile.models.Tag.objects.
+            get_or_create(tag_type=can_mentor, text=u'C#'))
+
+        link = mysite.profile.models.Link_Person_Tag(
+            person=Person.objects.get(user__username=u'paulproteus'),
+            tag=willing_to_mentor_csharp)
+        link.save()
+
+        banshee_mentor_count = banshee.mentor_count
+        csharp_mentor_count = banshee.language_mentor_count
+        self.assertEqual((0, 1), (banshee_mentor_count, csharp_mentor_count))
 
 
 class SuggestAlertOnLastResultsPage(TwillTests):


### PR DESCRIPTION
Continuing from  #1431:
1. Made changes to the views to check if the project has any mentors before displaying any URL
2. Added a new method has_mentors that returns True if the project has mentors
3. Added a new method language_mentors that returns the number of mentors in language of the project
4. Added test for point 3.
5. Could test the site it on my machine as clicking on projects would not load anything. Hence, I request you to test it on a faster machine before merging it.

Currently, there is a bug in the site
It says Mentors 3 ( and in Python).

It should be 
Mentors 3 ( and  <number> in Python).

This is what I intend to do in this fix.
