### PR TITLE
Patch for #1443

### DIFF
--- a/mysite/base/templates/robots_for_dev_env.txt
+++ b/mysite/base/templates/robots_for_dev_env.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/mysite/base/templates/robots_for_live_site.txt
+++ b/mysite/base/templates/robots_for_live_site.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: 

--- a/mysite/base/templates/robots_for_live_site.txt
+++ b/mysite/base/templates/robots_for_live_site.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: 
+Disallow:  

--- a/mysite/base/tests.py
+++ b/mysite/base/tests.py
@@ -50,6 +50,7 @@ import mysite.project.views
 
 import mysite.base.management.commands.nagios
 import mysite.profile.management.commands.send_emails
+from boto.dynamodb.condition import CONTAINS
 
 logger = logging.getLogger(__name__)
 
@@ -610,3 +611,28 @@ class GoogleApiTests(unittest.TestCase):
         # Check that latitude and longitude are returned and status is 'OK'
         geocode = mysite.base.view_helpers._geocode(response_data=response)
         self.assertNotEqual(geocode, None)
+
+
+# Test cases for robots generation
+class RenderRobotsTest(django.test.TestCase):
+    def test_robots_with_debug_true(self):
+        '''Set DEBUG to True in settings.py and verify that robots.txt contains
+         text identical to that seen in render_robots_for_dev_env.txt
+        '''
+        setattr(settings, "DEBUG", True)
+        response = self.client.get('/robots.txt')
+        robots_text = ""
+        with open('mysite/base/templates/robots_for_dev_env.txt') as f:
+            robots_text += f.read()
+        self.assertEqual(response.content, robots_text)
+        
+    def test_robots_with_debug_false(self):
+        '''Set DEBUG to False in settings.py and verify that robots.txt contains
+         text identical to that seen in render_robots_live_site.txt
+        '''
+        setattr(settings, "DEBUG", False)
+        response = self.client.get('/robots.txt')
+        robots_text = ""
+        with open('mysite/base/templates/robots_for_live_site.txt') as f:
+            robots_text += f.read()
+        self.assertEqual(response.content, robots_text)

--- a/mysite/base/tests.py
+++ b/mysite/base/tests.py
@@ -51,7 +51,6 @@ import mysite.settings
 
 import mysite.base.management.commands.nagios
 import mysite.profile.management.commands.send_emails
-from boto.dynamodb.condition import CONTAINS
 
 logger = logging.getLogger(__name__)
 

--- a/mysite/base/tests.py
+++ b/mysite/base/tests.py
@@ -47,6 +47,7 @@ import mysite.base.unicode_sanity
 import mysite.profile.views
 import mysite.base.views
 import mysite.project.views
+import mysite.settings
 
 import mysite.base.management.commands.nagios
 import mysite.profile.management.commands.send_emails
@@ -619,7 +620,7 @@ class RenderRobotsTest(django.test.TestCase):
         '''Set DEBUG to True in settings.py and verify that robots.txt contains
          text identical to that seen in render_robots_for_dev_env.txt
         '''
-        setattr(settings, "DEBUG", True)
+        mysite.settings.DEBUG = True
         response = self.client.get('/robots.txt')
         robots_text = ""
         with open('mysite/base/templates/robots_for_dev_env.txt') as f:
@@ -630,7 +631,7 @@ class RenderRobotsTest(django.test.TestCase):
         '''Set DEBUG to False in settings.py and verify that robots.txt contains
          text identical to that seen in render_robots_live_site.txt
         '''
-        setattr(settings, "DEBUG", False)
+        mysite.settings.DEBUG = False
         response = self.client.get('/robots.txt')
         robots_text = ""
         with open('mysite/base/templates/robots_for_live_site.txt') as f:

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -32,6 +32,7 @@ import mysite.customs.feed
 import mysite.search.view_helpers
 import mysite.search.models
 import mysite.missions.models
+import mysite.settings
 
 import random
 import datetime
@@ -277,9 +278,9 @@ def wordpress_index(request):
     return (request, template_path, data)
 
 def render_robots_txt(request):
-    if getattr(settings, "DEBUG", True):
+    if mysite.settings.DEBUG == True:
         template_path = "robots_for_dev_env.txt"
     else:
         template_path = "robots_for_live_site.txt"
-    return render_response(request, template_path, mimetype='text/plain')
 
+    return render_response(request, template_path, mimetype='text/plain')

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -32,13 +32,13 @@ import mysite.customs.feed
 import mysite.search.view_helpers
 import mysite.search.models
 import mysite.missions.models
-import mysite.settings
 
 import random
 import datetime
 import logging
 
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -276,9 +276,11 @@ def wordpress_index(request):
     return (request, template_path, data)
 
 def render_robots_txt(request):
-    if mysite.settings.DEBUG == True:
+    if getattr(settings, "DEBUG", True) == True:
+        logger.info("mysite settings is True")
         template_path = "robots_for_dev_env.txt"
     else:
+        logger.info("mysite settings is False")
         template_path = "robots_for_live_site.txt"
 
     return render_response(request, template_path, mimetype='text/plain')

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -38,6 +38,8 @@ import datetime
 import logging
 
 from django.contrib.auth.decorators import login_required
+from __builtin__ import getattr
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +277,9 @@ def wordpress_index(request):
     return (request, template_path, data)
 
 def render_robots_txt(request):
-    template_path = "robots.txt"
+    if getattr(settings, "DEBUG", True):
+        template_path = "robots_for_dev_env.txt"
+    else:
+        template_path = "robots_for_live_site.txt"
     return render_response(request, template_path, mimetype='text/plain')
 

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -39,8 +39,6 @@ import datetime
 import logging
 
 from django.contrib.auth.decorators import login_required
-from __builtin__ import getattr
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -38,6 +38,7 @@ import datetime
 import logging
 
 from django.contrib.auth.decorators import login_required
+from __builtin__ import getattr
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -277,10 +278,8 @@ def wordpress_index(request):
 
 def render_robots_txt(request):
     if getattr(settings, "DEBUG", True) == True:
-        logger.info("mysite settings is True")
         template_path = "robots_for_dev_env.txt"
     else:
-        logger.info("mysite settings is False")
         template_path = "robots_for_live_site.txt"
 
     return render_response(request, template_path, mimetype='text/plain')


### PR DESCRIPTION
I have written the tests and modified the views to return the correct robots.txt for different settings of mysite.settings.DEBUG . It works when mysite.settings.DEBUG = True. But when mysite.settings.DEBUG = False, it returns a 500 error. The tests seem to pass. 