### PR TITLE
Added a link in the 'Edit a Bug Set' page 

### DIFF
--- a/mysite/bugsets/templates/edit_index.html
+++ b/mysite/bugsets/templates/edit_index.html
@@ -34,6 +34,7 @@ Create Bug Set
     <form action="{{ request.get_full_path }}" method="post">
       {% csrf_token %}
       {{ form.as_p }}
+      <a href="{% url "mysite.bugsets.views.list_index" bugset.id bugset.name %}">View Live Bugset</a>
       <div id="button-container">
         <input type="submit" value="OK">
       </div>

--- a/mysite/bugsets/views.py
+++ b/mysite/bugsets/views.py
@@ -70,6 +70,7 @@ def create_index(request, pk=None, slug=None):
         context = {
             'form': form,
             'bugs': bugs,
+            'bugset': s,
         }
 
         return render(request, 'edit_index.html', context)

--- a/mysite/static/css/project/project.css
+++ b/mysite/static/css/project/project.css
@@ -144,3 +144,7 @@ body#project .tab_nav li, body#project .tab_nav h3 {
 body#project .tab_nav .ui-state-active h3 {
     background: white;
     }
+body#bugset_create #button-container {
+    display: inline;
+    float: right;
+}


### PR DESCRIPTION
Hi @paulproteus @ehashman @willingc @shaunagm,

I have added a link in the 'Edit a bugset' page to include a navigation link back to its list view of the set. Below screenshot shows my change.
![fix-1385](https://cloud.githubusercontent.com/assets/3911000/7120148/8074463e-e1fa-11e4-943d-9614d5ab1d82.jpg)

Please go through the code and let me know if I need to make any changes to the code.
This fixes the issue - https://github.com/openhatch/oh-mainline/issues/1385

Thanks,
Sunil