### PR TITLE
Fix for #1581, donation allows invalid text

### DIFF
--- a/mysite/base/templates/base/donate.html
+++ b/mysite/base/templates/base/donate.html
@@ -131,7 +131,7 @@
                                 <input type="hidden" name="t3" value="M">
                                 <input type="hidden" name="currency_code" value="USD">
                                 <input type="hidden" name="bn" value="PP-SubscriptionsBF:btn_subscribeCC_LG.gif:NonHostedGuest">
-                                <input name="a3" type="text" size="4">/month
+                                <input name="a3" type="number" size="4">/month
                                 <input type="submit" class="donation-button green" value="Donate!" style="margin-top: 4px;">
                             </form>
                             </td>
@@ -144,7 +144,7 @@
                                 <input type="hidden" name="currency_code" value="USD">
                                 <input type="hidden" name="no_note" value="0">
                                 <input type="hidden" name="bn" value="PP-DonationsBF:btn_donateCC_LG.gif:NonHostedGuest">
-                                <input name="amount" type="text" size="8">
+                                <input name="amount" type="number" size="8">
                                 <input type="submit" class="donation-button green" value="Donate!" style="margin-top: 4px;">
                             </form>
                             <td>


### PR DESCRIPTION
Browser support for this fix is approximately 88%. For those donating,
using invalid text, on IE8/IE9/Opera Mini the current behavior will
persist (PayPal error)