### PR TITLE
Fix robots.txt with DEBUG=False on localhost

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -55,6 +55,7 @@ DIRECTORY_CONTAINING_SETTINGS_PY = os.path.abspath(os.path.dirname(__file__))
 MEDIA_ROOT_BEFORE_STATIC = DIRECTORY_CONTAINING_SETTINGS_PY
 
 # Now, actual settings
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
As mentioned [here](https://github.com/openhatch/oh-mainline/pull/1551#issue-60255135), the application would throw a 500 error for requests to `robots.txt` when running on localhost with `DEBUG=False`