### PR TITLE
Change the IRC Nickname placeholder from ArcTanSusan to your_irc_nick

### DIFF
--- a/mysite/profile/forms.py
+++ b/mysite/profile/forms.py
@@ -80,7 +80,7 @@ class EditInfoForm(django.forms.Form):
         widget=django.forms.TextInput(
             attrs=
                 {
-                    'placeholder':'ArcTanSusan',
+                    'placeholder':'your_irc_nick',
                     'size':'40',
                 }
         )


### PR DESCRIPTION
as it was confusing to see a real nickname there.  Firefox on Windows shows placeholders in a not-very-pale grey, so it wasn't obvious that it was a placeholder.