### PR TITLE
Remove unneeded MySQL settings from migration

### DIFF
--- a/mysite/profile/migrations/0090_add_location_table.py
+++ b/mysite/profile/migrations/0090_add_location_table.py
@@ -9,8 +9,6 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         
         # Adding model 'Location'
-        if db.backend_name == 'mysql':
-            db.execute("SET storage_engine=INNODB; set names utf8;")
         db.create_table('profile_location', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('display_name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),


### PR DESCRIPTION
Remove unnecessary db settings that prevents Django from completing the mysql migration.

Needed step to address #1204 