### PR TITLE
Remove MySQL as an allowed failure in Travis - Closes #1618

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
 services:
   - mysql
 
-matrix:
-  allow_failures:
-    - env: USE_MYSQL=true
-
 install:
 # Install coveralls to test code coverage
  - sudo pip install coveralls


### PR DESCRIPTION
Closes #1618 

Updated Travis' configuration to remove MySQL fro allowed failures.