### PR TITLE
Rearranged Boston Python Workshop and OSCTC nodes in the events page

### DIFF
--- a/mysite/base/templates/base/events.html
+++ b/mysite/base/templates/base/events.html
@@ -53,23 +53,6 @@ document.documentElement.className = 'javascript_is_enabled';
     </div>
 
     <div class="module">
-      <a href="http://bostonpythonworkshop.com/"><img class="left-image" src="/static/images/bpw-180x180.jpg" /></a>
-      <div class="rest-of-box">
-	<div class="name-of-event">
-	  <a class="link-without-style" href="http://bostonpythonworkshop.com/">Boston Python Workshop</a>
-	</div>
-	<div>
-	  We empower women and their friends to learn practical programming in a beginner-friendly environment.
-	  By integrating the workshop into existing Python user groups, we retain attendees and build gender
-	  diversity into the main community.
-	</div>
-      </div>
-      <div class="little-read-more">
-	<a href="http://bostonpythonworkshop.com/">Read more &raquo;</a>
-      </div>
-    </div>
-
-    <div class="module">
       <a href="http://campus.openhatch.org/"><img class="left-image" src="/static/images/campus_IMG_6192_scaled.jpg" /></a>
       <div class="rest-of-box">
 	<div class="name-of-event">
@@ -83,6 +66,23 @@ document.documentElement.className = 'javascript_is_enabled';
       </div>
       <div class="little-read-more">
 	<a href="http://campus.openhatch.org/">Read more &raquo;</a>
+      </div>
+    </div>
+
+    <div class="module">
+      <a href="http://bostonpythonworkshop.com/"><img class="left-image" src="/static/images/bpw-180x180.jpg" /></a>
+      <div class="rest-of-box">
+	<div class="name-of-event">
+	  <a class="link-without-style" href="http://bostonpythonworkshop.com/">Boston Python Workshop</a>
+	</div>
+	<div>
+	  We empower women and their friends to learn practical programming in a beginner-friendly environment.
+	  By integrating the workshop into existing Python user groups, we retain attendees and build gender
+	  diversity into the main community.
+	</div>
+      </div>
+      <div class="little-read-more">
+	<a href="http://bostonpythonworkshop.com/">Read more &raquo;</a>
       </div>
     </div>
 


### PR DESCRIPTION
Hi @shaunagm @ehashman 

I have rearranged the 'Boston Python Workshop' and 'OSCTC' nodes in the events page.
This fixes https://github.com/openhatch/oh-mainline/issues/1602. 

Please review the changes and let me know if any more changes are required.

Thanks,
Sunil