### PR TITLE
Starting the client-side JS fetching of project data

### DIFF
--- a/mysite/base/templates/base/base.html
+++ b/mysite/base/templates/base/base.html
@@ -118,6 +118,7 @@
         <link rel="stylesheet/less" type="text/css" href="{% version '/static/less/base/landing.less' %}">
         {% endblock less %}
         <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js'></script>
         <script src="{% version '/static/js/less-1.3.0.min.js' %}" type="text/javascript"></script>
         {% block js_in_head %}
         {% endblock js_in_head %}

--- a/mysite/base/templates/base/base.html
+++ b/mysite/base/templates/base/base.html
@@ -118,7 +118,7 @@
         <link rel="stylesheet/less" type="text/css" href="{% version '/static/less/base/landing.less' %}">
         {% endblock less %}
         <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
-        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js'></script>
+        <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.14/jquery-ui.min.js'></script>
         <script src="{% version '/static/js/less-1.3.0.min.js' %}" type="text/javascript"></script>
         {% block js_in_head %}
         {% endblock js_in_head %}

--- a/mysite/scripts/deploy_myself.sh
+++ b/mysite/scripts/deploy_myself.sh
@@ -42,6 +42,11 @@ function update_database() {
 function notify_web_server() {
     ### Update the WSGI file so that Apache reloads the app.
     touch mysite/scripts/app.wsgi
+
+    ### Actually restart uwsgi since this doesn't seem to work.
+    ###
+    ### I hope the switch to Heroku makes this go away.
+    SUDO_ASKPASS=/bin/true sudo -A /etc/init.d/uwsgi restart || true
 }
 
 function notify_github() {

--- a/mysite/search/templates/search/result.html
+++ b/mysite/search/templates/search/result.html
@@ -50,6 +50,7 @@
             </div>
         {% endif %}
         <a href='{{ bug.project.get_url }}'>More about this project</a>
+        <button class='project_data_button' id='{{ bug.tracker_type }}'>See Project Data</button>
     </div>
 
 </div>

--- a/mysite/search/templates/search/result.html
+++ b/mysite/search/templates/search/result.html
@@ -50,7 +50,7 @@
             </div>
         {% endif %}
         <a href='{{ bug.project.get_url }}'>More about this project</a>
-        <button class='project_data_button' data-tracker='{{ bug.tracker_type_id }}' data-link='{{ bug.canonical_bug_link }}'>See project data</button>
+        <button class='project_data_button' data-tracker='{{ bug.tracker_type_id }}' data-id = '{{ bug.tracker_id }}' data-link='{{ bug.canonical_bug_link }}'>See project data</button>
     </div>
 
 </div>

--- a/mysite/search/templates/search/result.html
+++ b/mysite/search/templates/search/result.html
@@ -50,7 +50,7 @@
             </div>
         {% endif %}
         <a href='{{ bug.project.get_url }}'>More about this project</a>
-        <button class='project_data_button' id='{{ bug.tracker_type }}'>See Project Data</button>
+        <button class='project_data_button' data-tracker='{{ bug.tracker_type_id }}' data-link='{{ bug.canonical_bug_link }}'>See project data</button>
     </div>
 
 </div>

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -297,7 +297,7 @@ Volunteer opportunities in free and open source software
                 $.jGrowl(definition, { life: 100000 });
                 });
 
-            $(SearchResults.bindEventHandlers());
+            $(SearchResults.bindEventHandlers);
 
             });
 </script>

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -279,7 +279,6 @@ Volunteer opportunities in free and open source software
             {% endif %}
 
             <div id="projectModal" title="Project Data">
-                <p>This dialog is for project data</p>
             </div>
         </div>
     </div>

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -281,6 +281,9 @@ Volunteer opportunities in free and open source software
 
         </div>
 
+        <div id="projectModal" title="Project Data">
+            <p>This dialog is for project data</p>
+        </div>
     </div>
     {% endif %}
 

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -297,8 +297,9 @@ Volunteer opportunities in free and open source software
                 $.jGrowl(definition, { life: 100000 });
                 });
 
-            $(SearchResults.bindEventHandlers);
+            $(SearchResults.bindEventHandlers());
 
             });
 </script>
+<script src='static/js/search/apiWrapper.js' type='text/javascript'/>
 {% endblock js %}

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -278,11 +278,9 @@ Volunteer opportunities in free and open source software
             </div>
             {% endif %}
 
-
-        </div>
-
-        <div id="projectModal" title="Project Data">
-            <p>This dialog is for project data</p>
+            <div id="projectModal" title="Project Data">
+                <p>This dialog is for project data</p>
+            </div>
         </div>
     </div>
     {% endif %}

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -279,6 +279,8 @@ Volunteer opportunities in free and open source software
             {% endif %}
 
             <div id="projectModal" title="Project Data">
+                <div id="loadingWheel" style="display:none; position:absolute; left: 50%; top: 50%;"><img src="/static/images/snake.gif"/>
+                </div>
             </div>
         </div>
     </div>

--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -301,5 +301,5 @@ Volunteer opportunities in free and open source software
 
             });
 </script>
-<script src='static/js/search/apiWrapper.js' type='text/javascript'/>
+<script src='/static/js/search/apiWrapper.js' type='text/javascript'/>
 {% endblock js %}

--- a/mysite/search/views.py
+++ b/mysite/search/views.py
@@ -180,7 +180,6 @@ def search_index(request, invalid_subscribe_to_alert_form=None):
         data['total_bug_count'] = total_bug_count
         data['facet2any_query_string'] = facet2any_query_string
         data['project_count'] = mysite.search.view_helpers.get_project_count()
-        print data 
 
         return mysite.base.decorators.as_view(request, 'search/search.html', data, slug=None)
 

--- a/mysite/search/views.py
+++ b/mysite/search/views.py
@@ -77,7 +77,7 @@ def search_index(request, invalid_subscribe_to_alert_form=None):
 
     if query:
         bugs = query.get_bugs_unordered()
-
+            
         # Sort
         bugs = mysite.search.view_helpers.order_bugs(bugs)
 

--- a/mysite/search/views.py
+++ b/mysite/search/views.py
@@ -180,6 +180,7 @@ def search_index(request, invalid_subscribe_to_alert_form=None):
         data['total_bug_count'] = total_bug_count
         data['facet2any_query_string'] = facet2any_query_string
         data['project_count'] = mysite.search.view_helpers.get_project_count()
+        print data 
 
         return mysite.base.decorators.as_view(request, 'search/search.html', data, slug=None)
 

--- a/mysite/static/css/search/search.css
+++ b/mysite/static/css/search/search.css
@@ -87,6 +87,8 @@ body#search #results ul { margin: 0; padding: 0; float: left; width: 99%; }
         body#search #results li .project_data img { vertical-align: middle; opacity: 0.5; width: 20px; height: 20px; /* If ever an image is not square this rule might distort it. */  }
         body#search #results li .below_the_fold { color: #555; display: none; }
         body#search #results li .below_the_fold a {font-size: .9em; display: block; margin-top: 1em;}
+        body#search #results li .below_the_fold button {background:none!important; border:none; padding:0!important; font: inherit; color: #ff6d3d; cursor: pointer; outline: none;}
+        body#search #results li .below_the_fold button:hover {border-bottom:1px solid #ff6d3d;}
         body#search #results li .helpers { font-size: .8em; margin-top: 5px; }
         body#search #results li .helpers a { color: #ffa588; white-space: pre-wrap;}
         body#search #results li .helpers .no_mentors { color: #555;  }

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -28,7 +28,17 @@ var GithubWrapper = function(id, link) {
 	};
 
 	this.populateModal = function(data) {
-		$("#projectModal").attr('title', this.repo);
+		console.log(data);
+		var homepage = data['homepage'];
+		var description = data['description'];
+		var timeSinceCreation = getAge(data['created_at']);
+		var timeSinceUpdate = getAge(data['updated_at']);
+		$('#projectModal').dialog('option', 'title', data['name']);
+		var innerDialog = '<p><b>Description:</b> '+description+'</p>'+
+						  '<p><b>Homepage:</b> '+homepage+'</p>'+
+						  '<p><b>Age:</b> '+timeSinceCreation[0]+' years, '+timeSinceCreation[1]+' months, '+timeSinceCreation[2]+' days'+'</p>'+
+						  '<p><b>Last Updated:</b> '+timeSinceUpdate[0]+' years, '+timeSinceUpdate[1]+' months, '+timeSinceUpdate[2]+' days'+'</p>';
+		$("#projectModal").append(innerDialog);
 		$("#projectModal").dialog("open");
 	};
 };
@@ -46,12 +56,27 @@ var createAPIWrapper = function(tracker_type, link) {
 	currentWrapper.executeAPI();
 };
 
+//Get difference between a date and right now in years, months, days
+//Note: this is not exact (leap years, etc), but it's pretty good
+//We could include a library like Moment.js or Date.js
+var getAge = function(dateString) {
+    var today = new Date();
+    var startDate = new Date(dateString);
+    var years = Math.floor((today - startDate) / (1000*60*60*24*365.25));
+    var totalMonths = Math.floor((today - startDate)*12 / (1000*60*60*24*365.25));
+    var months = totalMonths - 12*years;
+    var totalDays = Math.floor((today - startDate) / (1000*60*60*24));
+    var days = totalDays - 365*years - (365.25/12)*months;
+    return [years, months, days];
+};
+
 $(function() {
 	//Define Project Modal
 	$("#projectModal").dialog({
 		autoOpen: false,
 		modal: true,
-		open: function(){
+		open: function() {
+			$("#projectModal").dialog("option", "position", {my: "center", at: "center", of: window});
 			$(".ui-widget-overlay").css({
             	opacity: .3,
             	filter: "Alpha(Opacity=30)",
@@ -60,6 +85,9 @@ $(function() {
             $('.ui-widget-overlay').bind('click',function(){
                 $('#projectModal').dialog('close');
             });
+        },
+        close: function(event, ui) {
+        	$("#projectModal").empty();
         }
 	});
 
@@ -74,9 +102,9 @@ $(function() {
 			console.log("Tracker_type not in mapping yet");
 		}
 	});
-});
 
-//When window resizes, keep modal in the middle
-$(window).resize(function() {
-    $("#projectModal").dialog("option", "position", {my: "center", at: "center", of: window});
+	//When window resizes, keep modal in the middle
+	$(window).resize(function() {
+    	$("#projectModal").dialog("option", "position", {my: "center", at: "center", of: window});
+	});
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -1,24 +1,55 @@
 //API Wrapper for Client
-var APIWrapper = function(id) {
-	this.id = id;
+var APIWrapper = function(id, link) {
+	this._id = Number(id);
+	this.link = link;
 };
 
 APIWrapper.prototype.toString = function() {
-	return this.id;
+	return this._id;
 };
 
 //Github Wrapper
-var GithubWrapper = function(id) {
-	APIWrapper.call(id);
+var GithubWrapper = function(id, link) {
+	APIWrapper.call(this, id, link);
+
+	var linkArray = link.split("/");
+
+	this.endpoint = 'https://api.github.com/repos/';
+	this.user = linkArray[3];
+	this.repo = linkArray[4];
+	this.issue = linkArray[6];
+
+	this.executeAPI = function(cb) {
+		var URL = this.endpoint+this.user+"/"+this.repo;
+		$.get(URL, function(data){
+			cb(data);
+		});
+	};
 };
 
 GithubWrapper.prototype = new APIWrapper();
 
+//ID-Api Mapping
+var mapping = {
+	89: GithubWrapper
+};
 
-
+//Function to create APIWrapper
+var createAPIWrapper = function(tracker_type, link) {
+	var currentWrapper = new mapping[tracker_type](tracker_type, link);
+	currentWrapper.executeAPI(function(data) {
+		console.log(data);
+	});
+};
 
 //Attach listeners to button
 $('.project_data_button').click(function() {
-	console.log(this);
-	alert(this);
+	var tracker_type = $(this).data("tracker");
+	var	link = $(this).data("link");
+	if (mapping.hasOwnProperty(tracker_type)) {
+		createAPIWrapper(tracker_type, link);
+	}
+	else {
+		console.log("Tracker_type not in mapping yet");
+	}
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -1,0 +1,3 @@
+$(document).ready(function() {
+    console.log("Chums");
+});

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -51,13 +51,11 @@ $(function() {
 	$("#projectModal").dialog({
 		autoOpen: false,
 		modal: true,
-		zIndex: 9999,
 		open: function(){
 			$(".ui-widget-overlay").css({
             	opacity: .3,
             	filter: "Alpha(Opacity=30)",
             	background: "black",
-            	position: "fixed",
         	});
             $('.ui-widget-overlay').bind('click',function(){
                 $('#projectModal').dialog('close');

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -34,22 +34,38 @@ var mapping = {
 	89: GithubWrapper
 };
 
+//Use data to populate modal
+var populateModal = function(data) {
+	$("#projectModal").dialog("open");
+};
+
 //Function to create APIWrapper
 var createAPIWrapper = function(tracker_type, link) {
 	var currentWrapper = new mapping[tracker_type](tracker_type, link);
-	currentWrapper.executeAPI(function(data) {
-		console.log(data);
-	});
+	currentWrapper.executeAPI(populateModal);
 };
 
-//Attach listeners to button
-$('.project_data_button').click(function() {
-	var tracker_type = $(this).data("tracker");
-	var	link = $(this).data("link");
-	if (mapping.hasOwnProperty(tracker_type)) {
-		createAPIWrapper(tracker_type, link);
-	}
-	else {
-		console.log("Tracker_type not in mapping yet");
-	}
+$(function() {
+	//Don't open project modal right away
+	$("#projectModal").dialog({
+		autoOpen: false,
+		modal: true,
+		open: function(){
+            jQuery('.ui-widget-overlay').bind('click',function(){
+                jQuery('#projectModal').dialog('close');
+            });
+        }
+	});
+
+	//Attach listeners to button
+	$('.project_data_button').click(function() {
+		var tracker_type = $(this).data("tracker");
+		var	link = $(this).data("link");
+		if (mapping.hasOwnProperty(tracker_type)) {
+			createAPIWrapper(tracker_type, link);
+		}
+		else {
+			console.log("Tracker_type not in mapping yet");
+		}
+	});
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -1,3 +1,23 @@
-$(document).ready(function() {
-    console.log("Chums");
+//API Wrapper for Client
+var APIWrapper = function(id) {
+	this.id = id;
+};
+
+APIWrapper.prototype.toString = function() {
+	return this.id;
+};
+
+//Github Wrapper
+var GithubWrapper = function(id) {
+	APIWrapper.call(id);
+};
+
+GithubWrapper.prototype = new APIWrapper();
+
+
+
+
+//Attach listeners to button
+$('.project_data_button').click(function() {
+	alert("hey");
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -19,5 +19,6 @@ GithubWrapper.prototype = new APIWrapper();
 
 //Attach listeners to button
 $('.project_data_button').click(function() {
-	alert("hey");
+	console.log(this);
+	alert(this);
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -1,11 +1,66 @@
+/**
+apiWrapper.js
+
+The Objects in this file represent wrapper around various bug tracker APIs.
+When possible, these wrappers inherit from a parent. They all inherit
+from APIWrapper. Individual wrappers like JiraMifos will inherit
+from the more general Mifos wrapper. This allows additional wrappers
+to be added for individual cases easily. You can override any attribute
+or method in a child by simply writing the method yourself in that class.
+
+All Wrapper objects must contain - or inherit - an executeAPI() function
+as well as a populateModal() function. The first of these two is the first
+and perhaps last set of function that makes the API request (callback should
+always be used in asynchronous situations). populateModal() simply
+fills in the popup modal with data recieved by the API request.
+
+Important distinctions made in this file - tracker_type, tracker_id.
+The tracker_type is one level of generalization over tracker_id. For
+example, tracker_type can be an integer that refers to the Launchpad
+bug tracker. However, each instance of Launchpad (heat, horizon, etc)
+will recieve their own tracker _id. 
+
+IMPORTANT: Make sure you have CORS enabled if you are developing locally.
+*/
+
+/**
+	TODO: 
+		1) Finish Python BugTracker
+		2) Make timeout on spinny wheel thing
+			Does that mean timeout on request too?
+			Fill the modal with a different message
+*/
+
+
+/**
+DataCache is a local (not currently using cookies) record of which APIs
+have been queried. This allows queries that take a long time to be
+remembered and loaded quickly. It also helps alleviate API use in cases
+where the API has some sort of limit (Github, for instance).
+*/
+var DataCache = {};
+
+//Add some data to the cache
+var addToCache = function(data) {
+	DataCache[data.tracker_id] = data.tracker_data;
+};
+
+//Check is data is in the cache
+var isInDataCache = function(_id) {
+	if (DataCache.hasOwnProperty(_id)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+//API Wrappers
 //Parent API Wrapper for Client
 var APIWrapper = function(type, id, link) {
 	this._type = type;
 	this._id = id;
 	this._link = link;
-	console.log(this);
 };
-
 APIWrapper.prototype.toString = function() {
 	return this._type;
 };
@@ -13,58 +68,184 @@ APIWrapper.prototype.toString = function() {
 //Github Wrapper
 var GithubWrapper = function(type, id, link) {
 	APIWrapper.call(this, type, id, link);
-	var _this = this;
 	this.endpoint = 'https://api.github.com/repos/';
-
-	var linkArray = this._link.split("/");
-	this.user = linkArray[3];
-	this.repo = linkArray[4];
-	this.issue = linkArray[6];
+	this.user = this._link.split("/")[3];
+	this.repo = this._link.split("/")[4];
+	this.issue = this._link.split("/")[6];
+	var _this = this;
 
 	this.executeAPI = function() {
+		$("#projectModal").dialog("open");
 		var URL = this.endpoint+this.user+"/"+this.repo;
-		$.get(URL, function(data) {
-			_this.populateModal(data);
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				addToCache({
+					tracker_id: _this._id, 
+					tracker_data: [data]
+				});
+				_this.populateModal(data);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
 		});
 	};
 
 	this.populateModal = function(data) {
 		var homepage = data['homepage'];
 		var description = data['description'];
+		if (description.length > 200) {
+			var sentences = description.split(". ");
+			description = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
 		var timeSinceCreation = getAge(data['created_at']);
 		var timeSinceUpdate = getAge(data['updated_at']);
 		$('#projectModal').dialog('option', 'title', data['name']);
 		var innerDialog = '<p><b>Description:</b> '+description+'</p>'+
-						  '<p><b>Homepage:</b> '+homepage+'</p>'+
-						  '<p><b>Project Age:</b> '+timeSinceCreation[0]+' years, '+timeSinceCreation[1]+' months, '+timeSinceCreation[2]+' days'+'</p>'+
-						  '<p><b>Last Updated:</b> '+timeSinceUpdate[0]+' years, '+timeSinceUpdate[1]+' months, '+timeSinceUpdate[2]+' days'+'</p>';
+						  '<p><b>Homepage:</b> <a href='+homepage+' >'+
+						  	homepage+'</a></p>'+
+						  '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+						  	' years, '+timeSinceCreation[1]+' months, '+
+						  	timeSinceCreation[2]+' days'+'</p>'+
+						  '<p><b>Last Updated:</b> '+timeSinceUpdate[0]
+						  	+' years, '+timeSinceUpdate[1]+' months, '
+						  	+timeSinceUpdate[2]+' days'+'</p>';
+		stopLoad();
 		$("#projectModal").append(innerDialog);
-		$("#projectModal").dialog("open");
 	};
 };
+GithubWrapper.prototype = Object.create(APIWrapper.prototype);
 
-GithubWrapper.prototype = new APIWrapper();
-
-
-//Jira Wrapper
-var JiraMifos = function(type, id, link) {
+//Bugzilla.Mozilla Wrapper
+var BugzillaMozilla = function(type, id, link) {
 	APIWrapper.call(this, type, id, link);
+	this.bugEndpoint = 'https://bugzilla.mozilla.org/rest/bug/';
+	this.productEndpoint = 'https://bugzilla.mozilla.org/rest/product/'; 
+	this.bugID = this._link.split("=")[1];
 	var _this = this;
-	this.endpoint = 'https://mifosforge.jira.com/rest/api/latest/issue/';
-
-	var linkArray = this._link.split("/");
-	this.issue = linkArray[4];
 
 	this.executeAPI = function() {
+		$('#projectModal').dialog("open");
+		var URL = this.bugEndpoint+this.bugID;
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				_this.executeProductAPI(
+					data["bugs"][0]["product"], data["bugs"][0]["component"]
+				);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
+		});
+	};
+
+	this.executeProductAPI = function(product, componentName) {
+		var URL = this.productEndpoint+product;
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				data['products'][0]['components'].forEach(function (component) {
+					if (component['name'] == componentName) {
+						addToCache({
+							tracker_id: _this._id, 
+							tracker_data: [data['products'][0], component]
+						});
+						_this.populateModal(data['products'][0], component);
+					}
+				});
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
+		});
+	};
+
+	this.populateModal = function(product, component) {
+		var productName = product['name'];
+		var productDescription = product['description'];
+		if (productDescription.length > 200) {
+			var sentences = productDescription.split(". ");
+			productDescription = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
+		var componentName = component['name'];
+		var componentDescription = component['description'];
+		$('#projectModal').dialog('option', 'title', productName+":"+componentName);
+		var innerDialog = '<p><b>Product:</b> '+productName+'</p>'+
+						  '<p><b>Product Desciption:</b> '+productDescription+'</p>'+
+						  '<p><b>Component:</b> '+componentName+'</p>'+
+						  '<p><b>Component Description:</b>'
+						  	+componentDescription+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
+	};
+};
+BugzillaMozilla.prototype = Object.create(APIWrapper.prototype);
+
+//Jira Wrapper - Main Wrapper for Jira Bug Tracker
+var JiraWrapper = function(type, id, link) {
+	APIWrapper.call(this, type, id, link);
+	this.issue = this._link.split("/")[4];
+	var _this = this;
+
+	this.executeAPI = function() {
+		$('#projectModal').dialog("open");
 		var URL = this.endpoint+this.issue;
-		$.get(URL, function(data) {
-			_this.executeProjectAPI(data, data['fields']['project']['self']);
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				_this.executeProjectAPI(data, data['fields']['project']['self']);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
 		});
 	};
 
 	this.executeProjectAPI = function(issueData, URL) {
-		$.get(URL, function(data) {
-			_this.populateModal(issueData, data)
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				addToCache({
+					tracker_id: _this._id, 
+					tracker_data: [issueData, data]
+				});
+				_this.populateModal(issueData, data);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
 		});
 	};
 
@@ -73,83 +254,273 @@ var JiraMifos = function(type, id, link) {
 		$('#projectModal').dialog('option', 'title', projectName);
 		var startDate = projectData['versions'][0]['releaseDate'];
 		var timeSinceCreation = getAge(startDate);
-		var innerDialog = '<p><b>Project Age:</b> '+timeSinceCreation[0]+' years, '+timeSinceCreation[1]+' months, '+timeSinceCreation[2]+' days'+'</p>';
+		var innerDialog = '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+							' years, '+timeSinceCreation[1]+' months, '+
+							timeSinceCreation[2]+' days'+'</p>';
+		stopLoad();
 		$('#projectModal').append(innerDialog);
-		$('#projectModal').dialog("open");
 	};
 };
+JiraWrapper.prototype = Object.create(APIWrapper.prototype);
 
-JiraMifos.prototype = new APIWrapper();
 
-//Bugzilla.Mozilla Wrapper
-var BugzillaMozilla = function(type, id, link) {
+//Jira Mifos Wrapper
+//Requires: this.endpoint - defines API endpoint
+//Optional: this.populateModal - overrides the method in the Parent
+var JiraMifos = function(type, id, link) {
+	this.endpoint = 'https://mifosforge.jira.com/rest/api/latest/issue/';
+	JiraWrapper.call(this, type, id, link);
+};
+JiraMifos.prototype = Object.create(JiraWrapper.prototype);
+
+//Jira Cyanogenmod Wrapper
+//Requires: this.endpoint - defines API endpoint
+//Optional: this.populateModal - overrides the method in the Parent
+var JiraCyanogenmod = function(type, id, link) {
+	this.endpoint = 'https://jira.cyanogenmod.org/rest/api/latest/issue/';
+	JiraWrapper.call(this, type, id, link);
+
+	this.populateModal = function(issueData, projectData) {
+		var projectName = projectData['name'];
+		$('#projectModal').dialog('option', 'title', projectName);
+		var projectDescription = projectData['description'];
+		if (projectDescription.length > 200) {
+			var sentences = projectDescription.split(". ");
+			projectDescription = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
+		var startDate = projectData['versions'][0]['releaseDate'];
+		var timeSinceCreation = getAge(startDate);
+		var innerDialog = '<p><b>Description:</b> '+projectDescription+'</p>'+
+		                  '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+		                  	' years, '+timeSinceCreation[1]+' months, '+
+		                  	timeSinceCreation[2]+' days'+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
+	};
+};
+JiraCyanogenmod.prototype = Object.create(JiraWrapper.prototype);
+
+//Sympy Wrapper - an example of simply going to the souce code for data
+var SympyWrapper = function(type, id, link) {
+	var sourceCode = "https://github.com/sympy/sympy/issues/foobar";
+	GithubWrapper.call(this, type, id, sourceCode);
+};
+SympyWrapper.prototype = Object.create(GithubWrapper.prototype);
+
+//Launchpad wrapper - Main Wrapper for bugs.launchpad.net
+var LaunchpadWrapper = function(type, id, link) {
 	APIWrapper.call(this, type, id, link);
+	this.endpoint = 'https://api.launchpad.net/devel/';
+	this.project = this._link.split("/")[3];
 	var _this = this;
-	this.bugEndpoint = 'https://bugzilla.mozilla.org/rest/bug/';
-	this.productEndpoint = 'https://bugzilla.mozilla.org/rest/product/'; 
-
-	var linkArray = this._link.split("=");
-	this.bugID = linkArray[1];
 
 	this.executeAPI = function() {
-		var URL = this.bugEndpoint+this.bugID;
-		$.get(URL, function(data) {
-			_this.executeProductAPI(data["bugs"][0]["product"], data["bugs"][0]["component"]);
-		});
-	};
-
-	this.executeProductAPI = function(product, componentName) {
-		var URL = this.productEndpoint+product;
-		$.get(URL, function(data) {
-			data['products'][0]['components'].forEach(function (component) {
-				if (component['name'] == componentName) {
-					_this.populateModal(data['products'][0], component);
-					console.log("Found our component");
-				}
-			});
-		});
-	};
-
-	this.populateModal = function(product, component) {
-		var productName = product['name'];
-		var productDescription = product['description']
-		var componentName = component['name'];
-		var componentDescription = component['description'];
-		$('#projectModal').dialog('option', 'title', productName+":"+componentName);
-		var innerDialog = '<p><b>Product:</b> '+productName+'</p>'+
-						  '<p><b>Product Desciption:</b> '+productDescription+'</p>'+
-						  '<p><b>Component:</b> '+componentName+'</p>'+
-						  '<p><b>Component Description:</b>'+componentDescription+'</p>';
-		$('#projectModal').append(innerDialog);
 		$('#projectModal').dialog("open");
+		var URL = this.endpoint + this.project;
+		$.ajax({
+			url: URL,
+			timeout: 3000,
+			success: function(data) {
+				addToCache({
+					tracker_id: _this._id, 
+					tracker_data: [data]
+				});
+				_this.populateModal(data);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
+		});
+	};
+
+	this.populateModal = function(data) {
+		var projectName = data['name'];
+		$('#projectModal').dialog('option', 'title', projectName);
+		var description = data['description'];
+		if (description.length > 200) {
+			var sentences = description.split(". ");
+			description = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
+		var homepage = data['homepage_url'];
+		var date_created = data['date_created'];
+		var timeSinceCreation = getAge(date_created);
+		var innerDialog = '<p><b>Description:</b> '+description+'</p>'+
+						  '<p><b>Homepage:</b> <a href='+homepage+' >'+
+						  	homepage+'</a></p>'+
+						  '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+						  	' years, '+timeSinceCreation[1]+' months, '+
+						  	timeSinceCreation[2]+' days'+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
 	};
 };
+LaunchpadWrapper.prototype = Object.create(APIWrapper.prototype);
 
-BugzillaMozilla.prototype = new APIWrapper();
+//Horizon Launchpad Wrapper
+var HorizonLaunchpad = function(type, id, link) {
+	LaunchpadWrapper.call(this, type, id, link);
+};
+HorizonLaunchpad.prototype = Object.create(LaunchpadWrapper.prototype);
 
-//ID-Api Mapping
-var mapping = {
+//Heat LaunchPad Wrapper
+var HeatLaunchpad = function(type, id, link) {
+	LaunchpadWrapper.call(this, type, id, link);
+};
+HeatLaunchpad.prototype = Object.create(LaunchpadWrapper.prototype);
+
+//UbuntuQualityManualTestcases LaunchPad Wrapper
+var UbuntuQualityManualTestcasesLaunchpad = function(type, id, link) {
+	LaunchpadWrapper.call(this, type, id, link);
+
+	this.populateModal = function(data) {
+		var projectName = data['name'];
+		$('#projectModal').dialog('option', 'title', projectName);
+		var description = data['description'];
+		if (description.length > 200) {
+			var sentences = description.split(". ");
+			description = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
+		var date_created = data['date_created'];
+		var timeSinceCreation = getAge(date_created);
+		var innerDialog = '<p><b>Description:</b> '+description+'</p>'+
+						  '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+						  	' years, '+timeSinceCreation[1]+' months, '+
+						  	timeSinceCreation[2]+' days'+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
+	};
+};
+UbuntuQualityManualTestcasesLaunchpad.prototype = 
+	Object.create(LaunchpadWrapper.prototype);
+
+//UbuntuQualityAutopilotTestcases LaunchPad Wrapper
+var UbuntuQualityAutopilotTestcasesLaunchpad = function(type, id, link) {
+	LaunchpadWrapper.call(this, type, id, link);
+
+	this.populateModal = function(data) {
+		var projectName = data['name'];
+		$('#projectModal').dialog('option', 'title', projectName);
+		var description = data['description'];
+		if (description.length > 200) {
+			var sentences = description.split(". ");
+			description = sentences[0]+'. '+sentences[1]+'. '+sentences[2]+'.';
+		}
+		var date_created = data['date_created'];
+		var timeSinceCreation = getAge(date_created);
+		var innerDialog = '<p><b>Description:</b> '+description+'</p>'+
+						  '<p><b>Project Age:</b> '+timeSinceCreation[0]+
+						  	' years, '+timeSinceCreation[1]+' months, '+
+						  	timeSinceCreation[2]+' days'+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
+	};
+};
+UbuntuQualityAutopilotTestcasesLaunchpad.prototype = 
+	Object.create(LaunchpadWrapper.prototype);
+
+//Stratagus LaunchPad Wrapper
+var StratagusLaunchpad = function(type, id, link) {
+	LaunchpadWrapper.call(this, type, id, link);
+};
+StratagusLaunchpad.prototype = Object.create(LaunchpadWrapper.prototype);
+
+//Openhatch Wrapper
+var OpenhatchWrapper = function(type, id, link) {
+	GithubWrapper.call(this, type, id, link);
+};
+OpenhatchWrapper.prototype = Object.create(GithubWrapper.prototype);
+
+//Python Wrapper - an example of scraping the 
+//web pages of the tracker for information
+var PythonWrapper = function(type, id, link) {
+	APIWrapper.call(this, type, id, link);
+	this.endpoint = 'http://bugs.python.org';
+	var _this = this;
+
+	this.executeAPI = function() {
+		$('#projectModal').dialog("open");
+		$.ajax({
+			url: _this.endpoint,
+			type: 'GET',
+			dataType: 'html',
+			timeout: 3000,
+			success: function(html) {
+				_this.populateModal(html);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				if (textStatus == 'timeout') {
+					populateTimeoutModal();
+				} else {
+					console.log(jqXHR, textStatus, errorThrown);
+					populateErrorModal(textStatus);
+				}
+			}
+		});
+	};
+
+	this.populateModal = function(newHTML) {
+		$('#projectModal').dialog('option', 'title', 'Python');
+		var tmp = $('<div></div>');
+		tmp.html(newHTML);
+		var firstBug = $('.odd', tmp).first();
+		var lastUpdated = $('.date', firstBug).first()[0];
+		var lastUpdatedText = $(lastUpdated).text();
+		var innerDialog = '<p><b>Last Updated:</b> '+lastUpdatedText+'</p>';
+		stopLoad();
+		$('#projectModal').append(innerDialog);
+	};	
+};
+PythonWrapper.prototype = Object.create(APIWrapper.prototype);
+
+//ID-Api IdMapping
+var IdMapping = {
+	//No Object for Github since they all work the same
 	89: GithubWrapper,
-	//Bugzilla Trackers
-	66: {
+	66: {  //Bugzilla
 		103: BugzillaMozilla
 	},
-	//Jira
-	91: {
-		264: JiraMifos
+	91: {  //Jira
+		264: JiraMifos,
+		242: JiraCyanogenmod
+	},
+	64: {  //Google - No API (either scrape or use source code)
+		36: SympyWrapper // example of just using source code
+	},
+	86: {  //Launchpad
+		215: HorizonLaunchpad,
+		274: HeatLaunchpad,
+		208: UbuntuQualityManualTestcasesLaunchpad,
+		209: UbuntuQualityAutopilotTestcasesLaunchpad,
+		250: StratagusLaunchpad
+	},
+	72: {
+		31: OpenhatchWrapper,
+		93: PythonWrapper
 	}
-	//64: GoogleWrapper - Doesn't exist?
-	//Trac
 };
 
 //Function to create APIWrapper
 var createAPIWrapper = function(tracker_type, tracker_id, link) {
-	if (typeof mapping[tracker_type] == 'object') {
-		var currentWrapper = new mapping[tracker_type][tracker_id](tracker_type, tracker_id, link);
+	var currentWrapper;
+	if (typeof IdMapping[tracker_type] == 'object') {
+		currentWrapper = 
+			new IdMapping[tracker_type][tracker_id](tracker_type, tracker_id, link);
 	} else {
-		var currentWrapper = new mapping[tracker_type](tracker_type, tracker_id, link);
+		currentWrapper = 
+			new IdMapping[tracker_type](tracker_type, tracker_id, link);
 	}
-	currentWrapper.executeAPI();
+	//If API Data is not in cache, execute it
+	if (!isInDataCache(tracker_id)) {
+		currentWrapper.executeAPI();
+	} else { //Else use current data for the job
+		$('#projectModal').dialog('open');
+		currentWrapper.populateModal.apply(this, DataCache[tracker_id]);
+	}
 };
 
 //Get difference between a date and right now in years, months, days
@@ -158,10 +529,13 @@ var createAPIWrapper = function(tracker_type, tracker_id, link) {
 var getAge = function(dateString) {
     var today = new Date();
     var startDate = new Date(dateString);
-    var years = Math.floor((today - startDate) / (1000*60*60*24*365.25));
-    var totalMonths = Math.floor((today - startDate)*12 / (1000*60*60*24*365.25));
+    var years = Math.floor((today - startDate) / 
+    	(1000*60*60*24*365.25));
+    var totalMonths = Math.floor((today - startDate)*12 / 
+    	(1000*60*60*24*365.25));
     var months = totalMonths - 12*years;
-    var totalDays = Math.floor((today - startDate) / (1000*60*60*24));
+    var totalDays = Math.floor((today - startDate) / 
+    	(1000*60*60*24));
     var days = totalDays - 365*years - (365.25/12)*months;
     return [years, months, days];
 };
@@ -172,6 +546,36 @@ var populateEmptyModal = function() {
 	var innerDialog = "<p>Sorry! This project's API has not been added yet!</p>";
 	$('#projectModal').append(innerDialog);
 	$('#projectModal').dialog('open');
+	stopLoad();
+};
+
+//Handle AJAX error - the modal is already open
+var populateErrorModal = function(textStatus) {
+	$('#projectModal').dialog('option', 'title', 'Error!');
+	var innerDialog = "<p>There was an error!</p>"+
+					  "<p>The error was: "+textStatus;
+	stopLoad();
+	$('#projectModal').append(innerDialog);
+};
+
+//Handle AJAX timeout - the modal is already open
+var populateTimeoutModal = function() {
+	$('#projectModal').dialog('option', 'title', 'Timeout!');
+	var innerDialog = "<p>Sorry! We took to long to load this!</p>"+
+					  "<p>Maybe try again?</p>"+
+					  "<p>If this happens repeatedly, there's probably something "+
+					  "wrong with this project's API</p>";
+	stopLoad();
+	$('#projectModal').append(innerDialog);
+};
+
+//Loading wheel animations
+var startLoad = function() {
+	$('#loadingWheel').show();
+};
+
+var stopLoad = function() {
+	$('#loadingWheel').hide();
 };
 
 $(function() {
@@ -179,19 +583,26 @@ $(function() {
 	$("#projectModal").dialog({
 		autoOpen: false,
 		modal: true,
+		width: "40%",
 		open: function() {
-			$("#projectModal").dialog("option", "position", {my: "center", at: "center", of: window});
+			$("#projectModal").dialog("option", "position", {
+				my: "center", 
+				at: "center", 
+				of: window});
 			$(".ui-widget-overlay").css({
             	opacity: .3,
             	filter: "Alpha(Opacity=30)",
             	background: "black",
         	});
+        	startLoad();
             $('.ui-widget-overlay').bind('click',function(){
                 $('#projectModal').dialog('close');
             });
         },
         close: function(event, ui) {
-        	$("#projectModal").empty();
+        	var wheel = $("#loadingWheel");
+        	$("#projectModal").html(wheel);
+        	$('#projectModal').dialog('option', 'title', '');
         }
 	});
 
@@ -200,28 +611,33 @@ $(function() {
 		var tracker_type = $(this).data("tracker");
 		var tracker_id = $(this).data("id");
 		var	link = $(this).data("link");
-		if (mapping.hasOwnProperty(tracker_type)) {
-			if (typeof mapping[tracker_type] != 'object') {
+		if (IdMapping.hasOwnProperty(tracker_type)) {
+			if (typeof IdMapping[tracker_type] != 'object') {
 				createAPIWrapper(tracker_type, tracker_id, link);
 			} else {
-				if (mapping[tracker_type].hasOwnProperty(tracker_id)) {
+				if (IdMapping[tracker_type].hasOwnProperty(tracker_id)) {
 					createAPIWrapper(tracker_type, tracker_id, link);
 				} else {
-					console.log(tracker_id);
-					console.log("Tracker_id not in mapping yet");
+					console.log("Tracker_type:"+tracker_type+
+									", Tracker_id:"+tracker_id+
+									" not in IdMapping yet");
 					populateEmptyModal();
 				}
 			}
 		}
 		else {
-			console.log(tracker_type);
-			console.log("Tracker_type not in mapping yet");
+			console.log("Tracker_type:"+tracker_type+
+							", Tracker_id:"+tracker_id+
+							" not in IdMapping yet");
 			populateEmptyModal();
 		}
 	});
 
 	//When window resizes, keep modal in the middle
 	$(window).resize(function() {
-    	$("#projectModal").dialog("option", "position", {my: "center", at: "center", of: window});
+    	$("#projectModal").dialog("option", "position", {
+    		my: "center", 
+    		at: "center", 
+    		of: window});
 	});
 });

--- a/mysite/static/js/search/apiWrapper.js
+++ b/mysite/static/js/search/apiWrapper.js
@@ -13,17 +13,22 @@ var GithubWrapper = function(id, link) {
 	APIWrapper.call(this, id, link);
 
 	var linkArray = link.split("/");
+	var _this = this;
 
 	this.endpoint = 'https://api.github.com/repos/';
 	this.user = linkArray[3];
 	this.repo = linkArray[4];
 	this.issue = linkArray[6];
 
-	this.executeAPI = function(cb) {
+	this.executeAPI = function() {
 		var URL = this.endpoint+this.user+"/"+this.repo;
 		$.get(URL, function(data){
-			cb(data);
+			_this.populateModal(data);
 		});
+	};
+
+	this.populateModal = function(data) {
+		$("#projectModal").dialog("open");
 	};
 };
 
@@ -34,15 +39,10 @@ var mapping = {
 	89: GithubWrapper
 };
 
-//Use data to populate modal
-var populateModal = function(data) {
-	$("#projectModal").dialog("open");
-};
-
 //Function to create APIWrapper
 var createAPIWrapper = function(tracker_type, link) {
 	var currentWrapper = new mapping[tracker_type](tracker_type, link);
-	currentWrapper.executeAPI(populateModal);
+	currentWrapper.executeAPI();
 };
 
 $(function() {

--- a/mysite/static/js/search/search.js
+++ b/mysite/static/js/search/search.js
@@ -62,7 +62,12 @@ SearchResults.bindEventHandlers = function () {
             $('#results li').removeClass('expanded');
             return false;
             });
+    console.log("Chums");
 
 }
 
 /* vim: set ai ts=4 sts=4 et sw=4: */
+
+$(document).ready(function() {
+    console.log("Chums");
+});

--- a/mysite/static/js/search/search.js
+++ b/mysite/static/js/search/search.js
@@ -62,12 +62,7 @@ SearchResults.bindEventHandlers = function () {
             $('#results li').removeClass('expanded');
             return false;
             });
-    console.log("Chums");
 
 }
 
 /* vim: set ai ts=4 sts=4 et sw=4: */
-
-$(document).ready(function() {
-    console.log("Chums");
-});

--- a/vendor/packages/django-debug-toolbar/debug_toolbar/settings.py
+++ b/vendor/packages/django-debug-toolbar/debug_toolbar/settings.py
@@ -19,6 +19,7 @@ CONFIG_DEFAULTS = {
     'DISABLE_PANELS': set(['debug_toolbar.panels.redirects.RedirectsPanel']),
     'INSERT_BEFORE': '</body>',
     'JQUERY_URL': '//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js',
+    'JQUERY_UI_URL': '//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js',
     'RENDER_PANELS': None,
     'RESULTS_STORE_SIZE': 10,
     'ROOT_TAG_EXTRA_ATTRS': '',

--- a/vendor/packages/django-debug-toolbar/debug_toolbar/settings.py
+++ b/vendor/packages/django-debug-toolbar/debug_toolbar/settings.py
@@ -19,7 +19,7 @@ CONFIG_DEFAULTS = {
     'DISABLE_PANELS': set(['debug_toolbar.panels.redirects.RedirectsPanel']),
     'INSERT_BEFORE': '</body>',
     'JQUERY_URL': '//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js',
-    'JQUERY_UI_URL': '//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js',
+    'JQUERY_UI_URL': '//ajax.googleapis.com/ajax/libs/jqueryui/1.8.14/jquery-ui.min.js',
     'RENDER_PANELS': None,
     'RESULTS_STORE_SIZE': 10,
     'ROOT_TAG_EXTRA_ATTRS': '',

--- a/vendor/packages/django-debug-toolbar/debug_toolbar/templates/debug_toolbar/base.html
+++ b/vendor/packages/django-debug-toolbar/debug_toolbar/templates/debug_toolbar/base.html
@@ -7,6 +7,7 @@
 <!-- Prevent our copy of jQuery from registering as an AMD module on sites that use RequireJS. -->
 <script>var _djdt_define_backup = window.define; window.define = undefined;</script>
 <script src="{{ toolbar.config.JQUERY_URL }}"></script>
+<script src="{{ toolbar.config.JQUERY_UI_URL }}"></script>
 <script>var djdt = {jQuery: jQuery.noConflict(true)}; window.define = _djdt_define_backup;</script>
 {% else %}
 <script>var djdt = {jQuery: jQuery};</script>


### PR DESCRIPTION
Hi all

So I was a part of some brief discussion about including project data in the search results page. There was some good talk, but I thought things would be a little easier if I just got an MVP out there and we could talk about it. I decided to go with a purely client-side solution because it would require the least amount of tempering with the back-end, but that's definitely a route we can go down if people think it's better.

To check this out, search for anything basically. Then find a bug that is being tracked using the Github Issue Tracker. Expand that bug, then look for the "See project data" button right under the "More about this project" link. Click it to check out a modal that pops up with data gleaned from the Github API. It's pretty basic right now. But I wanted to get some feedback before I:
- Added more and cooler data from Github
- Added other issue trackers besides Github
- Clean up my code (but it's not unreadable at this point :) )
- Write tests (pretty trivial anyway)
- Optimize for API request limits
- Squash my commits

Here's a screenshot of one example

![image](https://cloud.githubusercontent.com/assets/2695564/7334421/f19c6472-eb5f-11e4-9381-ec10198daec5.png)

Feel free to email me (chumbleya@gmail.com) if you have any questions/comments. Thanks!
