### PR TITLE
Remove unused legacy function commit_poll - fixes #1646

### DIFF
--- a/mysite/missions/svn/views.py
+++ b/mysite/missions/svn/views.py
@@ -174,8 +174,3 @@ class Commit(SvnBaseView):
     this_mission_page_short_name = 'Committing your changes'
     mission_step_prerequisite = 'svn_diff'
     template_name = 'missions/svn/commit.html'
-
-
-@login_required
-def commit_poll(request):
-    return HttpResponse(json.dumps(view_helpers.mission_completed(request.user.get_profile(), 'svn_commit')))

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -196,8 +196,6 @@ urlpatterns = patterns('',
                         'mysite.missions.svn.views.checkout_submit'),
                        (r'^missions/svn/diff/submit$',
                         'mysite.missions.svn.views.diff_submit'),
-                       (r'^missions/svn/commit/poll$',
-                        'mysite.missions.svn.views.commit_poll'),
 
                        (r'^missions/git$',
                         'mysite.missions.git.views.main_page'),


### PR DESCRIPTION
Fixes issue #1646 by removing the unused function commit_poll and its associated entry in urls.py.