### PR TITLE
Add form display to SVN mission view (PR #1648 related)

### DIFF
--- a/mysite/missions/svn/views.py
+++ b/mysite/missions/svn/views.py
@@ -171,6 +171,7 @@ class Diff(SvnBaseView):
         data = super(Diff, self).get_context_data(*args, **kwargs)
         if kwargs.has_key('extra_context_data'):
             data.update(kwargs['extra_context_data'])
+        data['svn_diff_form'] = forms.DiffForm()
         return data
 
 


### PR DESCRIPTION
The change in #1648 removed some code. One of the lines deleted is added back in this PR so that the  form text box loads on the initial diff view.