### PR TITLE
Remove redundant 'Code docs' link to the OpenHatch docs on homepage

### DIFF
--- a/mysite/base/templates/base/base.html
+++ b/mysite/base/templates/base/base.html
@@ -178,7 +178,6 @@
 		  <li><a href="http://openhatch.readthedocs.org/en/latest">Intro for developers</a></li>
 		  <li><a href="https://github.com/openhatch/oh-mainline">Github (source code)</a></li>
 		  <li><a href="http://lists.openhatch.org/mailman/listinfo/devel">Devel mailing list</a></li>
-		  <li><a href="http://openhatch.readthedocs.org/">Code docs</a></li>
 		  <li><a href="https://openhatch.org/bugs/">Bug tracker</a></li>
 		</ul>
 	      </div>


### PR DESCRIPTION
Fixes #1657. :-)