### PR TITLE
Swap expand/collapse when a bug is expanded/collapsed - issue #1536

### DIFF
--- a/mysite/search/templates/search/result.html
+++ b/mysite/search/templates/search/result.html
@@ -73,7 +73,7 @@
             </a>
         </div>
         <div class='top_right'>
-            <span class='expand'><a href='javascript:void(0);'>expand</a></span>
+            <span class='expand'><a href='javascript:void(0);' class="expand-link">expand</a></span>
             <span class='sep'>&middot;</span>
             <span class='link'><a 
                         rel='tipsy-south'

--- a/mysite/static/js/search/search.js
+++ b/mysite/static/js/search/search.js
@@ -18,6 +18,8 @@
 */
 
 $.fn.toggleExpanded = function() {
+    var expandLink = this.find('.expand-link');
+    expandLink.text(expandLink.text() == "expand" ? "collapse" : "expand");
     this.toggleClass('expanded');
     return this;
 };
@@ -55,11 +57,13 @@ SearchResults.bindEventHandlers = function () {
 
     $('#expand-all-link').click(function() {
             $('#results li').addClass('expanded');
+            $('.expand-link').text('collapse');
             return false;
             });
 
     $('#collapse-all-link').click(function() {
             $('#results li').removeClass('expanded');
+            $('.expand-link').text('expand');
             return false;
             });
 


### PR DESCRIPTION
When selecting "expand" on a bug, the link text will become "collapse" and vice-versa. It will also swap them when selecting "expand all"/"collapse all". (Issue #1536)