### PR TITLE
Fix footer alignment on missions pages

### DIFF
--- a/mysite/missions/templates/missions/mission_base.html
+++ b/mysite/missions/templates/missions/mission_base.html
@@ -99,6 +99,7 @@
 	</div>
 	{% endblock mission_main %}
 </div>
+</div>
 {% endblock main %}
 
 {% block title %}


### PR DESCRIPTION
mentioned in #1599 and #1641, the footer on these pages was being styled
within the "container" div due to a missing closing tag. I think I've
tracked it down and corrected it. 

The following is what I currently see on the live site:

![screen shot 2015-06-15 at 10 18 24 pm](https://cloud.githubusercontent.com/assets/4661088/8175207/7f9518f4-13ac-11e5-8855-7552af0032e3.png)

and with the change made in the PR I see the following:

![screen shot 2015-06-15 at 10 15 52 pm](https://cloud.githubusercontent.com/assets/4661088/8175217/9e71fa76-13ac-11e5-9f2a-c66f320abdeb.png)

and all seems well on the other training pages:

![screen shot 2015-06-15 at 10 17 24 pm](https://cloud.githubusercontent.com/assets/4661088/8175225/c7c62046-13ac-11e5-9fdd-c1de70020f11.png)

I think this fix is pretty straight forward; I've checked things on Firefox, Chrome and Safari but if someone could review it on their own machine as well that'd be great.