### PR TITLE
Fixed "What's This?" displaying only once

### DIFF
--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -289,7 +289,7 @@ Volunteer opportunities in free and open source software
 {% block js %}
 <script type='text/javascript'>
     $(function () {
-            $('#define-bite-size').one("click",function () {
+            $('#define-bite-size').on("click",function () {
                 var definition = (
                     '<dt><strong>Bite-size</strong> [\ˈbaɪtˌsaɪz\], adj.</dt>' + 
                     '<dd>Good for newcomers; ' +


### PR DESCRIPTION
Changed line 292 to call ".on" instead of ".one". This fixes a portion of issue #1595.  

Regarding the position of the text, it seems that $.jGrowl is being used to display the information. jGrowl defaults only to only 5 different positions ( top-left, top-right, bottom-left, bottom-right, center), so I cannot currently edit the position of the box. However, I have fixed the issue where clicking the box only displays it once.