### PR TITLE
Moved "What's this?" from default top-right to modified center

### DIFF
--- a/mysite/search/templates/search/search.html
+++ b/mysite/search/templates/search/search.html
@@ -288,6 +288,7 @@ Volunteer opportunities in free and open source software
 
 {% block js %}
 <script type='text/javascript'>
+    $.jGrowl.defaults.position = 'center';
     $(function () {
             $('#define-bite-size').on("click",function () {
                 var definition = (

--- a/mysite/static/css/base/jquery.jgrowl.css
+++ b/mysite/static/css/base/jquery.jgrowl.css
@@ -63,9 +63,9 @@ body > div.jGrowl.bottom-right {
 }
 
 body > div.jGrowl.center {
-	top: 				0px;
+	top: 				40%;
 	width: 				50%;
-	left: 				25%;
+	left: 				16%;
 }
 
 /** Cross Browser Styling **/


### PR DESCRIPTION
This displays the definition popup near the center of the screen(I moved it not exactly at the center so that the x to close the popup displays close under the button). 

I do not know why there are currently margin errors, but this should fix any issues with having the popup appear at the top-right.

Edit: Also, the clarify, the margin errors are not a result of this change. This seems to be an issue before-hand.
