### PR TITLE
Update wording for log in pages

### DIFF
--- a/mysite/account/templates/account/login.html
+++ b/mysite/account/templates/account/login.html
@@ -43,7 +43,7 @@ form { width: 350px; }
 
 <div id='login' class='module'>
     <div class='module-head'>
-        <h3>Log in with an account you already own</h3>
+        <h3>Log in with OpenID</h3>
     </div>
     <div class='module-body'>
 
@@ -107,11 +107,7 @@ form { width: 350px; }
             {% endif %}
 
             <ul class='login-links'>
-                <h4 style='width: 95%;'>Relatedly</h4>
-
-                <li><a href='/blog/2009/why-we-support-openid'>
-                    What is OpenID?
-                </a></li>
+                <h4 style='width: 95%;'>Related</h4>
 
                 <li><a href='{% url "oh_login_pwd" %}?next={{ next|urlencode }}'>
                     Log in with a password

--- a/mysite/account/templates/account/login_old.html
+++ b/mysite/account/templates/account/login_old.html
@@ -46,7 +46,7 @@ form {
             </form>
         </div>
         <ul class='login-links'>
-            <h4 style='width: 95%;'>Relatedly</h4>
+            <h4 style='width: 95%;'>Related</h4>
             <li><a href='/account/login'>Log in with OpenID</a></li>
             <li><a href='/account/signup'>Sign up without OpenID</a></li>
             <li><a href='/account/forgot_pass'>Forgot your password?</a></li>

--- a/mysite/account/templates/account/login_openid.html
+++ b/mysite/account/templates/account/login_openid.html
@@ -21,7 +21,7 @@
     {% if next and not answers and not request.GET.from_offsite %}
         <p>Please log in to proceed.</p>
     {% endif %}
-    <p id='please_click'>Which account would you like to use?</p>
+    <p id='please_click'>Choose an account below to log in with OpenID. (<a href='/blog/2009/why-we-support-openid'>What is OpenID?</a>)</p>
     <input type="hidden" name="action" value="verify" />
     <input type="hidden" name="next" value="{{ next }}" />
     <div id="openid_choice">


### PR DESCRIPTION
This is a fix for issue #451.

mysite/account/templates/account/login_old.html:
Change “Relatedly” to “Related”. It’s a good generic term for
describing things related to login.

mysite/account/templates/account/login_openid.html:
Change wording to imperative. This is clearer than previous wording.
Also, add link to “What is OpenID?” blog post as it makes more sense
next to have it here rather than off to the side.

mysite/account/templates/account/login.html:
Change wording to use OpenID. This is now consistent with other usage
elsewhere.

Also change “Relatedly” to “Related” for consistency.

James