### PR TITLE
Fix jGrowl message wrapping inappropriately

### DIFF
--- a/mysite/static/css/account/settings.css
+++ b/mysite/static/css/account/settings.css
@@ -15,6 +15,11 @@ body.settings,body.missions #main .submodule .body { background-color: #fff; pad
     width: 0%
 }
 
+div.message {
+    background-color: #000;
+    width: 100%;
+}
+
 #notification {
 	display: none;
 }


### PR DESCRIPTION
Fix for unexpected wrapping of jGrowl popup as mentioned in fix #1595.

The jGrowl popup which is created when clicking “What’s this?” next to
“bitesize” created a popup which was wrapping the message text after
every word. This was happening because the div message class was
inheriting “width: 0%” from .default div in settings.css.

This change fixes that by giving divs their own message class with
“width: 100%”.

The popup was also inheriting “background-color: #FF6D3D;” from the
.default div class, but you couldn’t see it (presumably) because width
was 0%.

This commit also fixes that and sets the background to the expected
#000 (black) color.