### PR TITLE
Add commit hash to footer

### DIFF
--- a/mysite/base/templates/base/base.html
+++ b/mysite/base/templates/base/base.html
@@ -179,6 +179,9 @@
 		  <li><a href="https://github.com/openhatch/oh-mainline">Github (source code)</a></li>
 		  <li><a href="http://lists.openhatch.org/mailman/listinfo/devel">Devel mailing list</a></li>
 		  <li><a href="https://openhatch.org/bugs/">Bug tracker</a></li>
+		  {% if current_commit_hash %}
+		  <li><a href="https://github.com/openhatch/oh-mainline/commit/{{ current_commit_hash }}">SHA-1: {{ current_commit_hash }}</a></li>
+		  {% endif %}
 		</ul>
 	      </div>
 

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -52,6 +52,7 @@ def front_page_data():
         mysite.search.models.WannaHelperNote.objects.order_by('-created_date')[:5])
     feed_items.sort(key=lambda x: x.modified_date, reverse=True)
     data['recent_feed_items'] = feed_items[:5]
+    data['current_commit_hash'] = settings.COMMIT_HASH
     return data
 
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -1,6 +1,7 @@
 #Django settings for the basic OpenHatch 'mysite' project
 
 # Imports
+import subprocess
 import os
 import logging
 import datetime
@@ -407,3 +408,8 @@ IRC_MISSION_SERVER_PRETTYNAME = 'Freenode'
 IRC_MISSION_CHANNEL = '#oh-ircmission-test'
 IRC_MISSIONBOT_NICK = 'oh_bottest'
 IRC_MISSIONBOT_REALNAME = 'OpenHatch Mission Bot'
+
+# the most recent commit hash, included in the main page footer for bug
+# reporting/debugging
+COMMIT_HASH = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
+                              stdout=subprocess.PIPE).stdout.read().strip()

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -409,7 +409,10 @@ IRC_MISSION_CHANNEL = '#oh-ircmission-test'
 IRC_MISSIONBOT_NICK = 'oh_bottest'
 IRC_MISSIONBOT_REALNAME = 'OpenHatch Mission Bot'
 
-# the most recent commit hash, included in the main page footer for bug
+# the most recent git commit hash, included in the main page footer for bug
 # reporting/debugging
-COMMIT_HASH = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
+try:
+    COMMIT_HASH = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
                               stdout=subprocess.PIPE).stdout.read().strip()
+except OSError: # git not found on system path
+    COMMIT_HASH = None


### PR DESCRIPTION
For feature #1676 to aid in debugging and troubleshooting the live
site. Currently only visible on the home page.

This is mostly intended to drive the discussion on this feature, as a proof of concept. The commit hash and link is included only on the main page footer, I think ideally it'd be in the footer on every page but I think that is infeasible because of how the footer is rendered in the `base.html` template (and therefore not invoked in a single view function).

The link is to the commit itself in `oh-mainline` on Github and looks like the rest of the links:
<img width="766" alt="screen shot 2015-07-05 at 3 59 58 pm" src="https://cloud.githubusercontent.com/assets/4661088/8513385/f1a7692e-232e-11e5-8b9f-a9af806c8797.png">

In the event that the git command fails in any way, the `COMMIT_HASH` variable in `settings.py` will be empty/falsey and the template will render as it does today (and on every page that isn't Home):
<img width="800" alt="screen shot 2015-07-05 at 4 03 15 pm" src="https://cloud.githubusercontent.com/assets/4661088/8513400/798d1a64-232f-11e5-87a7-740cfca3cada.png">

I thought `settings.py` was the most logical place for this information, and the logic is pretty minimal. But if there is a better suggestion I'm open to it.
