### PR TITLE
Fix github url regexes

### DIFF
--- a/mysite/customs/forms.py
+++ b/mysite/customs/forms.py
@@ -143,7 +143,7 @@ class LaunchpadTrackerForm(TrackerFormThatHidesCreatedForProject):
 
 class GitHubTrackerForm(TrackerFormThatHidesCreatedForProject):
     github_url = django.forms.RegexField(
-        regex=r'^https?:\/\/github.com\/[\_\-\w]+\/[\_\-\w]+$',
+        regex=r'^https?:\/\/github.com\/[a-zA-Z0-9\-]+\/[\-\w.]+$',
         max_length=200,
         required=True,
         help_text='This is the url of the GitHub project.',
@@ -159,7 +159,7 @@ class GitHubTrackerForm(TrackerFormThatHidesCreatedForProject):
         github_url = self.cleaned_data['github_url']
 
         github_name_repo = re.match(
-            r'^https?:\/\/github.com\/([\_\-\w]+)\/([\_\-\w.]+)$',
+            r'^https?:\/\/github.com\/([a-zA-Z0-9\-]+)\/([\-\w.]+)$',
             github_url
         )
 

--- a/mysite/customs/tests.py
+++ b/mysite/customs/tests.py
@@ -777,7 +777,7 @@ class GitHubTrackerEditingViews(WebTest):
             select_subclasses().count())
         form = mysite.customs.forms.GitHubTrackerForm({
             'tracker_name': 'KDE Github',
-            'github_url': 'https://github.com/kde/project-A',
+            'github_url': 'https://github.com/kde/Super-cool_project.1',
             'created_for_project': self.kde.id,
             'bitsized_tag': 'easy',
             'max_connections': '8',


### PR DESCRIPTION
The first regex wasn't allowing dots in repository names, so many valid project URLs aren't accepted by http://openhatch.org/customs/add/github.