### PR TITLE
Fix spacing for coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,7 @@ README
    :target: http://travis-ci.org/openhatch/oh-mainline
 
 .. image:: https://coveralls.io/repos/openhatch/oh-mainline/badge.svg?branch=master&service=github
-  :target: https://coveralls.io/github/openhatch/oh-mainline?branch=master
-
+   :target: https://coveralls.io/github/openhatch/oh-mainline?branch=master
 
 .. image:: http://codecov.io/github/openhatch/oh-mainline/coverage.svg?branch=master
    :target: http://codecov.io/github/openhatch/oh-mainline?branch=master


### PR DESCRIPTION
A minor typo fix to make coveralls not complain that our badge does not exist.

