### PR TITLE
Add CSRF Token to Post Request for Reordering projects to prevent 403

### DIFF
--- a/mysite/static/js/importer.js
+++ b/mysite/static/js/importer.js
@@ -958,6 +958,21 @@ $(PortfolioEntry.Add.init);
 /*
  *      Re-order projects
  *-------------------------*/
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie != '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
 
 PortfolioEntry.Reorder = {
     '$list': null,
@@ -1018,10 +1033,13 @@ PortfolioEntry.Reorder = {
                 $(this).text('Working...').attr('disabled','disabled');
                 PortfolioEntry.Reorder.$done_reordering = $(this);
 
+                var csrftoken = getCookie('csrftoken');
+
                 var options = {
                     'type': 'POST',
                     'url': '/+do/save_portfolio_entry_ordering_do',
                     'data': query_string,
+                    headers: { "X-CSRFToken": csrftoken },
                     'success': function () {
                         PortfolioEntry.Reorder.$list.remove();
                         $('#portfolio_entries *').not('.loading_message').remove();


### PR DESCRIPTION
This addresses: https://github.com/openhatch/oh-mainline/issues/1567.

The root cause for this problem was that the view `save_portfolio_entry_ordering_do` in `base/views.py` has the annotation `@login_required`, which requires a CSRF token to be passed.
In the absence of this token, the response status is a 403, which causes the cryptic `Merde: there was an error saving your ordering` to be displayed.