### PR TITLE
Clean up git mission tests and related mission submodule #1711

### DIFF
--- a/mysite/base/decorators.py
+++ b/mysite/base/decorators.py
@@ -15,23 +15,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from decorator import decorator
-from odict import odict
-import logging
-from django.http import HttpResponse
-import re
 import collections
-import mysite.base.view_helpers
-import json
-import django.core.cache
-import hashlib
+from decorator import decorator
 from functools import partial
+import hashlib
+import json
+import logging
+from odict import odict
+import re
 
-from django.template.loader import render_to_string
-import django.db.models.query
-from mysite.base.view_helpers import render_response
-from django.core.urlresolvers import reverse, resolve
 import django.contrib.auth.decorators
+import django.core.cache
+from django.core.urlresolvers import reverse, resolve
+import django.db.models.query
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+
+import mysite.base.view_helpers
+from mysite.base.view_helpers import render_response
+
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +55,7 @@ def as_view(request, template, data, slug, just_modify_data=False):
     # Depends on whether this is a login-requiring page.
     try:
         view_function, _, _ = resolve(request.path)
-        is_login_required = isinstance(view_function,
-                                       django.contrib.auth.decorators._CheckLogin)
+        is_login_required = isinstance(view_function, django.contrib.auth.decorators._CheckLogin)
         if is_login_required:
             data['go_here_after_logging_in_or_out'] = '/'
         else:
@@ -76,14 +77,12 @@ def view(func, *args, **kw):
     slug = func.__name__  # Used by account settings
     return as_view(request, template, view_data, slug)
 
-# vim: ai ts=3 sts=4 et sw=4 nu
-
 
 @decorator
 def unicodify_strings_when_inputted(func, *args, **kwargs):
-    '''Decorator that makes sure every argument passed in that is
+    """Decorator that makes sure every argument passed in that is
     a string-esque type is turned into a Unicode object. Does so
-    by decoding UTF-8 byte strings into Unicode objects.'''
+    by decoding UTF-8 byte strings into Unicode objects."""
     args_as_list = list(args)
     # first, *args
     for i in range(len(args)):
@@ -142,8 +141,7 @@ def cache_function_that_takes_request(func, *args, **kwargs):
     # 3. query string
     key_data.append(request.META.get('QUERY_STRING', ''))
 
-    key_string = 'cache_request_function_' + \
-        hashlib.sha1(repr(key_data)).hexdigest()
+    key_string = 'cache_request_function_' + hashlib.sha1(repr(key_data)).hexdigest()
     content = django.core.cache.cache.get(key_string, None)
     if content:
         logger.info("Cache hot for %s", repr(key_data))

--- a/mysite/base/depends.py
+++ b/mysite/base/depends.py
@@ -29,6 +29,7 @@ import os
 import logging
 import django.conf
 
+logger = logging.getLogger(__name__)
 
 # class used if module does not exist
 class nothing(object):
@@ -45,9 +46,7 @@ except:
     lxml.html = None
 
 if lxml.html is None:
-    logging.info("Some parts of the OpenHatch site may fail because the "
-                 "lxml library is not installed. Look in "
-                 "ADVANCED_INSTALLATION.mkd for information about lxml.")
+    logger.info("Some parts of the OpenHatch site may fail because the lxml library is not installed. Look in ADVANCED_INSTALLATION.md for information about lxml.")
 
 
 # Pillow, PIL, Images - Here we try to import "Image", from the Python Imaging Library.
@@ -84,8 +83,6 @@ def postmap_available(already_emitted_warning=[]):
             pass
         else:
             already_emitted_warning.append(True)
-            logging.warn('postmap binary not found at {0}. Look in '
-                         'ADVANCED_INSTALLATION for the section about '
-                         'postfix for more information.'.format(POSTMAP_PATH))
+            logger.warn('postmap binary not found at {0}. Look in ADVANCED_INSTALLATION for the section about postfix for more information.'.format(POSTMAP_PATH))
         return False
     return True

--- a/mysite/base/feeds.py
+++ b/mysite/base/feeds.py
@@ -30,7 +30,6 @@ class RecentActivityFeed(Feed):
 
     def items(self):
         feed_items = list(Answer.objects.order_by('-modified_date')[:15])
-        feed_items.extend(
-            WannaHelperNote.objects.order_by('-modified_date')[:15])
+        feed_items.extend(WannaHelperNote.objects.order_by('-modified_date')[:15])
         feed_items.sort(key=lambda x: x.modified_date, reverse=True)
         return feed_items[:15]

--- a/mysite/base/management/commands/remote_command_check.py
+++ b/mysite/base/management/commands/remote_command_check.py
@@ -21,11 +21,8 @@ from django.contrib.auth.models import User
 from django.core.management import BaseCommand, CommandError
 
 
-VALID_COMMANDS = (
-    ['milestone-a/manage.py', 'git_reset'],
-    ['milestone-a/manage.py', 'git_exists'],
-    ['milestone-a/manage.py', 'svn_reset'],
-    ['milestone-a/manage.py', 'svn_exists'],
+VALID_COMMANDS = (['milestone-a/manage.py', 'git_reset'], ['milestone-a/manage.py', 'git_exists'],
+    ['milestone-a/manage.py', 'svn_reset'], ['milestone-a/manage.py', 'svn_exists'],
 )
 
 

--- a/mysite/base/middleware.py
+++ b/mysite/base/middleware.py
@@ -21,7 +21,6 @@ import staticgenerator.middleware
 
 
 def get_user_ip(request):
-#    return request.META['REMOTE_ADDR']
     if request.META['REMOTE_ADDR'] == '127.0.0.1':
         return "98.140.110.121"
     else:
@@ -34,11 +33,8 @@ class HandleWannaHelpQueue(object):
         if not hasattr(request, 'user') or not hasattr(request, 'session'):
             return None
 
-        if (hasattr(request, 'user') and
-            request.user.is_authenticated() and
-                'wanna_help_queue_handled' not in request.session):
-            mysite.project.view_helpers.flush_session_wanna_help_queue_into_database(
-                request.user, request.session)
+        if (hasattr(request, 'user') and request.user.is_authenticated() and 'wanna_help_queue_handled' not in request.session):
+            mysite.project.view_helpers.flush_session_wanna_help_queue_into_database(request.user, request.session)
             request.session['wanna_help_queue_handled'] = True
         return None
 
@@ -52,19 +48,17 @@ class DetectLogin(object):
             return response
 
         if request.user.is_authenticated() and 'post_login_stuff_run' not in request.session:
-            mysite.project.view_helpers.take_control_of_our_answers(
-                request.user, request.session)
+            mysite.project.view_helpers.take_control_of_our_answers(request.user, request.session)
             request.session['post_login_stuff_run'] = True
         return response
 
 
 class StaticGeneratorMiddlewareOnlyWhenAnonymous(object):
-
-    '''This is a wrapper around
+    """This is a wrapper around
     staticgenerator.middleware.StaticGeneratorMiddleware that only saves to the
     cache when request.user.is_authenticated() is False.
 
-    We never want to do static generation for when people are logged in.'''
+    We never want to do static generation for when people are logged in."""
 
     def process_response(self, request, response):
         # If somehow the request has no 'user' attribute, bail.

--- a/mysite/base/models.py
+++ b/mysite/base/models.py
@@ -45,25 +45,22 @@ class Timestamp(models.Model):
 
     @staticmethod
     def update_timestamp_for_string(s, override_time=None):
-        timestamp, _ = Timestamp.objects.get_or_create(key=Timestamp.hash(s), defaults={
-            'timestamp': datetime.datetime.utcnow()})
+        timestamp, _ = Timestamp.objects.get_or_create(key=Timestamp.hash(s), defaults={'timestamp': datetime.datetime.utcnow()})
         timestamp.timestamp = override_time or datetime.datetime.utcnow()
         timestamp.save()  # definitely!
         return timestamp
 
     @staticmethod
     def key_for_model(cls):
-        '''This is a helper function that lets the user pass us a model, and
+        """This is a helper function that lets the user pass us a model, and
         we generate the key to use.
 
         It just takes the class name and prepends
-        "model last updated " to it.'''
+        "model last updated " to it."""
         s = 'model last updated ' + cls.__module__ + '.' + cls.__name__
         return s
 
 # Adjustments to default Django sqlite3 behavior
-
-
 def activate_foreign_keys(sender, connection, **kwargs):
     """Enable integrity constraint with sqlite."""
     if connection.vendor == 'sqlite':

--- a/mysite/base/templatetags/base_extras.py
+++ b/mysite/base/templatetags/base_extras.py
@@ -43,8 +43,7 @@ def timesince_terse(value, **args):
     if type(value) == time.struct_time:
         # icky, but do it
         secs_since_epoch = calendar.timegm(value)
-        value = datetime.datetime.fromtimestamp(
-            secs_since_epoch)
+        value = datetime.datetime.fromtimestamp(secs_since_epoch)
 
     string = timesince(value, **args)
     ret = string.split(", ")[0]
@@ -147,8 +146,7 @@ def urlize_without_escaping_percent_signs(text, trim_url_limit=None, nofollow=Fa
     # I think this is a copy of a function in django.utils.html with one minor
     # change; see the comment below.
 
-    trim_url = lambda x, limit=trim_url_limit: limit is not None and (
-        len(x) > limit and ('%s...' % x[:max(0, limit - 3)])) or x
+    trim_url = lambda x, limit=trim_url_limit: limit is not None and (len(x) > limit and ('%s...' % x[:max(0, limit - 3)])) or x
     safe_input = isinstance(text, SafeData)
     words = word_split_re.split(force_unicode(text))
     nofollow_attr = nofollow and ' rel="nofollow"' or ''
@@ -230,16 +228,13 @@ def version(path_string):
     """ Based on Stuart Colville's code at this blog post:
     http://muffinresearch.co.uk/archives/2008/04/08/automatic-asset-versioning-in-django/
     """
-    if settings.ADD_VERSION_STRING_TO_IMAGES and (
-            settings.ADD_VERSION_STRING_TO_IMAGES_IN_DEBUG_MODE
-            or not settings.DEBUG):
+    if settings.ADD_VERSION_STRING_TO_IMAGES and (settings.ADD_VERSION_STRING_TO_IMAGES_IN_DEBUG_MODE or not settings.DEBUG):
         try:
             if path_string in version_cache:
                 mtime = version_cache[path_string]
             else:
                 try:
-                    mtime = os.path.getmtime(
-                        '%s%s' % (settings.MEDIA_ROOT_BEFORE_STATIC, path_string,))
+                    mtime = os.path.getmtime('%s%s' % (settings.MEDIA_ROOT_BEFORE_STATIC, path_string,))
                 except (OSError, IOError):
                     mtime = 0
                 version_cache[path_string] = mtime

--- a/mysite/base/tests.py
+++ b/mysite/base/tests.py
@@ -18,45 +18,41 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-import django.test
-from django.core.urlresolvers import reverse
-
-import twill
-from twill import commands as tc
-from django.core.handlers.wsgi import WSGIHandler
-from django.contrib.staticfiles.handlers import StaticFilesHandler
-from StringIO import StringIO
-from django.test.client import Client
-import os
-import os.path
-import subprocess
-
-from django.core.cache import cache
-from django.core.management import CommandError
-from django.conf import settings
-from django.contrib.auth.models import User
-
-import mock
 import datetime
 import logging
+import mock
+import os
+import os.path
+from StringIO import StringIO
+import subprocess
+import twill
+from twill import commands as tc
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.contrib.staticfiles.handlers import StaticFilesHandler
+from django.core.cache import cache
+from django.core.handlers.wsgi import WSGIHandler
+from django.core.management import CommandError
+import django.test
+from django.test.client import Client
 from django.utils import unittest
-from django.utils.unittest import expectedFailure, skip
+from django.utils.unittest import skip
+from django.core.urlresolvers import reverse
 
-import mysite.base.view_helpers
 import mysite.base.decorators
-import mysite.search.models
-import mysite.base.templatetags.base_extras
-import mysite.base.unicode_sanity
-import mysite.profile.views
-import mysite.base.views
-import mysite.project.views
-import mysite.settings
-
+import mysite.base.depends
 import mysite.base.management.commands.nagios
 import mysite.base.management.commands.remote_command_check
+import mysite.base.templatetags.base_extras
+import mysite.base.unicode_sanity
+import mysite.base.view_helpers
+import mysite.base.views
 import mysite.profile.management.commands.send_emails
-
+import mysite.profile.views
+import mysite.project.views
+import mysite.search.models
+import mysite.settings
 logger = logging.getLogger(__name__)
 
 
@@ -691,3 +687,17 @@ class RenderDevRobotsTest(django.test.TestCase):
 
     def tearDown(self):
         settings.DEBUG = self.original_value
+
+
+#class DependsTests(django.test.TestCase):
+
+    # def test_postmap_available_warning_emitted(self):
+    #     warning_emitted = True
+    #     response = self.postmap_available(warning_emitted)
+    #     self.assertTrue(response)
+
+    # def test_postmap_available_warning_not_emitted(self):
+    #     warning_emitted = False
+    #     response = postmap_available(self, warning_emitted)
+    #     assertTrue(response)
+

--- a/mysite/base/unicode_sanity.py
+++ b/mysite/base/unicode_sanity.py
@@ -20,16 +20,16 @@
 # that stress me out.
 
 # Sadly our dependencies use them, so I can't.
-import urllib
-import cStringIO as StringIO
 
+import cStringIO as StringIO
 import decorator
+import urllib
 
 @decorator.decorator
 def unicodify_strings_when_inputted(func, *args, **kwargs):
-    '''Decorator that makes sure every argument passed in that is
+    """Decorator that makes sure every argument passed in that is
     a string-esque type is turned into a Unicode object. Does so
-    by decoding UTF-8 byte strings into Unicode objects.'''
+    by decoding UTF-8 byte strings into Unicode objects."""
     args_as_list = list(args)
     # first, *args
     for i in range(len(args)):
@@ -63,7 +63,7 @@ def wrap_file_object_in_utf8_check(f):
 
 
 def utf8(s):
-    '''This function takes a bytestring or a Unicode object
+    """This function takes a bytestring or a Unicode object
     as its input, and it outputs a bytestring that is UTF-8
     encoded.
 
@@ -74,7 +74,7 @@ def utf8(s):
     Django with one particular difference: this function will
     raise a UnicodeDecodeError if you pass in a bytestring that
     cannot be decoded into UTF-8. This is a feature; in the case
-    of invalid data, we refuse the temptation to guess.'''
+    of invalid data, we refuse the temptation to guess."""
     # If the input is a bytestring, then we use the unicode
     # constructor to up-convert it:
     try:

--- a/mysite/base/views.py
+++ b/mysite/base/views.py
@@ -19,26 +19,26 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.http import HttpResponse, HttpResponseBadRequest
-from mysite.base.view_helpers import render_response
+import datetime
 import json
+import logging
+import random
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.template import loader, Context
 
 import mysite.account
-import mysite.profile.view_helpers
 import mysite.account.forms
 from mysite.base.decorators import view
+from mysite.base.view_helpers import render_response
 import mysite.customs.feed
+import mysite.missions.models
+import mysite.profile.view_helpers
 import mysite.search.view_helpers
 import mysite.search.models
-import mysite.missions.models
 
-import random
-import datetime
-import logging
-
-from django.contrib.auth.decorators import login_required
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +60,7 @@ def front_page_data():
 def home(request):
     data = front_page_data()
 
-    everybody = list(
-        mysite.profile.models.Person.objects.exclude(link_person_tag=None))
+    everybody = list(mysite.profile.models.Person.objects.exclude(link_person_tag=None))
     random.shuffle(everybody)
     data['random_profiles'] = everybody[0:5]
 
@@ -72,18 +71,15 @@ def home(request):
 
         data['nudge_location'] = person.should_be_nudged_about_location()
         data['nudge_tags'] = not person.get_tags_for_recommendations()
-        data['nudge_missions'] = not mysite.missions.models.StepCompletion.objects.filter(
-            person=person)
+        data['nudge_missions'] = not mysite.missions.models.StepCompletion.objects.filter(person=person)
 
 
         if person.get_published_portfolio_entries():
-            data['nudge_importer_when_user_has_some_projects'
-                 ] = True  # just nudge about the importer...
+            data['nudge_importer_when_user_has_some_projects'] = True  # just nudge about the importer...
         else:
             # the person has entered zero projects and hasn't touched the importer
             # so introduce him or her to use the importer!
-            data['nudge_importer_when_user_has_no_projects'
-                 ] = True  # give the general project editing nudge
+            data['nudge_importer_when_user_has_no_projects'] = True  # give the general project editing nudge
 
         data['show_nudge_box'] = (data['nudge_location'] or
                                   'nudge_importer_when_user_has_no_projects' in data or data['nudge_tags'] or
@@ -91,25 +87,17 @@ def home(request):
 
         # For performance reasons, we do not send bug recommendations here.
 
-        completed_missions = dict((c.step.name, True)
-                                  for c in mysite.missions.models.StepCompletion.objects.filter(person=request.user.get_profile()))
+        completed_missions = dict((c.step.name, True) for c in mysite.missions.models.StepCompletion.objects.filter(person=request.user.get_profile()))
         data[u'completed_missions'] = completed_missions
 
         data[u'projects_i_wanna_help'] = person.projects_i_wanna_help.all()
         data[u'projects_i_helped'] = person.get_published_portfolio_entries()
 
         # These are for project maintainers
-        data[u'projects_with_wannahelpers'] = [
-            pfe.project for pfe in person.get_published_portfolio_entries()
-            if pfe.project.wannahelpernote_set.all().count()]
+        data[u'projects_with_wannahelpers'] = [pfe.project for pfe in person.get_published_portfolio_entries() if pfe.project.wannahelpernote_set.all().count()]
         data[u'maintainer_nudges'] = maintainer_nudges = {}
-        maintainer_nudges['show_project_page'] = (
-            person.get_published_portfolio_entries() and
-            not person.user.answer_set.all())
-        maintainer_nudges[u'add_bug_tracker'] = (
-            person.get_published_portfolio_entries() and
-            (not any([pfe.project.bug_set.all()
-                      for pfe in person.get_published_portfolio_entries()])))
+        maintainer_nudges['show_project_page'] = (person.get_published_portfolio_entries() and not person.user.answer_set.all())
+        maintainer_nudges[u'add_bug_tracker'] = (person.get_published_portfolio_entries() and (not any([pfe.project.bug_set.all() for pfe in person.get_published_portfolio_entries()])))
     else:  # no user logged in. Show front-page
         template_path = 'base/index.html'
 
@@ -124,16 +112,12 @@ def page_to_js(request):
     encoded_for_js = json.dumps(html_doc)
     # Note: using application/javascript as suggested by
     # http://www.ietf.org/rfc/rfc4329.txt
-    return render_response(request, 'base/append_ourselves.js',
-                           {'in_string': encoded_for_js},
-                           mimetype='application/javascript')
+    return render_response(request, 'base/append_ourselves.js', {'in_string': encoded_for_js}, mimetype='application/javascript')
 
 
 def page_not_found(request):
     t = loader.get_template('404.html')
-    c = Context({
-        'user': request.user
-    })
+    c = Context({'user': request.user })
 
     response = HttpResponse(t.render(c), status=404)
     return response
@@ -144,13 +128,11 @@ def geocode(request):
     if not address:
         return HttpResponseBadRequest()  # no address :-(
     # try to geocode
-    coordinates_as_json = mysite.base.view_helpers.cached_geocoding_in_json(
-        address)
+    coordinates_as_json = mysite.base.view_helpers.cached_geocoding_in_json(address)
     if coordinates_as_json == 'null':
         # We couldn't geocode that.
         return HttpResponseBadRequest()  # no address :-(
-    return HttpResponse(coordinates_as_json,
-                        mimetype='application/json')
+    return HttpResponse(coordinates_as_json, mimetype='application/json')
 
 # Obtains meta data for request return
 
@@ -162,23 +144,18 @@ def meta_data():
     # local name for shortness
     my = data['bug_diagnostics']
 
-    one_hour_and_two_days_ago = (datetime.datetime.now() -
-                                 datetime.timedelta(days=2, hours=1))
+    one_hour_and_two_days_ago = (datetime.datetime.now() - datetime.timedelta(days=2, hours=1))
 
-    my['Bugs last polled more than than two days + one hour ago'] = mysite.search.models.Bug.open_ones.filter(
-        last_polled__lt=one_hour_and_two_days_ago).count()
+    my['Bugs last polled more than than two days + one hour ago'] = mysite.search.models.Bug.open_ones.filter(last_polled__lt=one_hour_and_two_days_ago).count()
 
-    three_days_ago = (datetime.datetime.now() -
-                      datetime.timedelta(days=3))
-    my['Bugs last polled more than three days ago'] = mysite.search.models.Bug.open_ones.filter(
-        last_polled__lt=three_days_ago).count()
+    three_days_ago = (datetime.datetime.now() - datetime.timedelta(days=3))
+    my['Bugs last polled more than three days ago'] = mysite.search.models.Bug.open_ones.filter(last_polled__lt=three_days_ago).count()
 
     # Test for 0 division
     allbug = mysite.search.models.Bug.open_ones.count()
     perbug = 0.0
     if allbug:
-        perbug = (mysite.search.models.Bug.open_ones.filter(
-            last_polled__lt=three_days_ago).count() * 100.0 / allbug)
+        perbug = (mysite.search.models.Bug.open_ones.filter(last_polled__lt=three_days_ago).count() * 100.0 / allbug)
 
     my['Bugs last polled more than three days ago (in percent)'] = perbug
 
@@ -211,7 +188,7 @@ def meta_exit_code(data=None):
 
 @view
 def meta(request):
-    return (request, 'meta.html', meta_data())
+    return request, 'meta.html', meta_data()
 
 
 @login_required
@@ -233,20 +210,17 @@ def save_portfolio_entry_ordering_do(request):
 
 @view
 def landing_for_opp_hunters(request):
-    return (request, 'landing_for_opp_hunters.html',
-            front_page_data())
+    return request, 'landing_for_opp_hunters.html', front_page_data()
 
 
 @view
 def landing_for_project_maintainers(request):
-    return (request, 'landing_for_project_maintainers.html',
-            front_page_data())
+    return request, 'landing_for_project_maintainers.html', front_page_data()
 
 
 @view
 def landing_for_documenters(request):
-    return (request, 'landing_for_documenters.html',
-            front_page_data())
+    return request, 'landing_for_documenters.html', front_page_data()
 
 
 @login_required
@@ -256,25 +230,24 @@ def test_email_re_projects(request):
     command = send_emails.Command()
     command.this_run_covers_things_since = datetime.datetime(2009, 5, 28)
     command.this_run_covers_things_up_until = datetime.datetime.utcnow()
-    context = command.get_context_for_email_to(
-        request.user.get_profile()) or {}
+    context = command.get_context_for_email_to(request.user.get_profile()) or {}
     if context:
         return mysite.base.decorators.as_view(request, 'email_re_projects.html', context, "test_email_re_projects")
     else:
-        return HttpResponse("(We couldn't find any recent project activity for you, so you wouldn't get an email updating you about it.)")
+        return HttpResponse("We couldn't find any recent project activity for you, so you wouldn't get an email updating you about it.")
+
 
 # The following view(s) generate stub pages that get converted
 # into themes for other system(s).
 #
 # Right now, there's only one for a single page in a single
 # other theming system. Enjoy!
-
-
 @view
 def wordpress_index(request):
     template_path = 'base/wordpress_index.html'
     data = {}
-    return (request, template_path, data)
+    return request, template_path, data
+
 
 def render_robots_txt(request):
     if settings.DEBUG:

--- a/mysite/missions/git/forms.py
+++ b/mysite/missions/git/forms.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import django.forms
 import re
-
+import django.forms
 
 class ConfigForm(django.forms.Form):
     BAD_ENDINGS = ['local', 'none', 'host']
@@ -28,29 +27,24 @@ class ConfigForm(django.forms.Form):
     def clean_user_email(self):
         for ending in ConfigForm.BAD_ENDINGS:
             if self.cleaned_data['user_email'].endswith(ending):
-                raise django.forms.ValidationError, (
-                    'The email address is invalid '
-                    'because it ends with %s' % (ending,))
+                raise django.forms.ValidationError(
+                    'The email address is invalid because it ends with {0:s}'.format(ending, ))
 
 
 class CheckoutForm(django.forms.Form):
-    secret_word = django.forms.CharField(
-        error_messages={'required': 'No author was given.'})
+    secret_word = django.forms.CharField(error_messages={'required': 'No author was given.'})
 
 
 class DiffForm(django.forms.Form):
-    diff = django.forms.CharField(
-        error_messages={'required': 'No git diff output was given.'}, widget=django.forms.Textarea())
+    diff = django.forms.CharField(error_messages={'required': 'No git diff output was given.'}, widget=django.forms.Textarea())
 
     def clean_diff(self):
         REGEX_DIFF_LINE = '\+print "[H,h]ello,?[ ]+[w,W]orld\!'
         success_count = re.search(REGEX_DIFF_LINE, self.cleaned_data['diff'])
         if success_count == None:
-            raise django.forms.ValidationError, (
-                "Something doesn't look right.The expected line is '+print... ' Give it another try!")
+            raise django.forms.ValidationError("Something doesn't look right.The expected line is '+print... ' Give it another try!")
         return self.cleaned_data['diff']
 
 
 class RebaseForm(django.forms.Form):
-    secret_word = django.forms.CharField(
-        error_messages={'required': 'The password was incorrect.'})
+    secret_word = django.forms.CharField(error_messages={'required': 'The password was incorrect.'})

--- a/mysite/missions/git/tests.py
+++ b/mysite/missions/git/tests.py
@@ -28,11 +28,9 @@ class GitViewTestsWhileLoggedOut(TwillTests):
         self.client = self.login_with_client()
         self.client.logout()
 
-    def test_main_page_does_not_complain_about_prereqs_even_if_logged_out(
-            self):
+    def test_main_page_does_not_complain_about_prereqs_even_if_logged_out(self):
         response = self.client.get(reverse(views.main_page))
-        self.assertTrue(response.context[0]
-                        ['mission_step_prerequisites_passed'])
+        self.assertTrue(response.context[0]['mission_step_prerequisites_passed'])
 
 
 class GitViewTests(TwillTests):
@@ -48,8 +46,7 @@ class GitViewTests(TwillTests):
 
     def test_main_page_does_not_complain_about_prereqs(self):
         response = self.client.get(reverse(views.main_page))
-        self.assertTrue(response.context[0]
-                        ['mission_step_prerequisites_passed'])
+        self.assertTrue(response.context[0]['mission_step_prerequisites_passed'])
 
     def test_resetrepo_returns_error_with_get(self):
         response = self.client.get(reverse(views.resetrepo))
@@ -61,61 +58,46 @@ class GitViewTests(TwillTests):
 
     def test_do_checkout_mission_correctly(self):
         word = 'the brain'
-        self.client.post(reverse(views.checkout_submit),
-                         {'secret_word': word})
+        self.client.post(reverse(views.checkout_submit), {'secret_word': word})
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assert_(
-            view_helpers.mission_completed(paulproteus, 'git_checkout'))
+        self.assert_(view_helpers.mission_completed(paulproteus, 'git_checkout'))
 
     def test_do_checkout_mission_incorrectly(self):
         word = 'the wrong word'
-        self.client.post(reverse(views.checkout_submit),
-                         {'secret_word': word})
+        self.client.post(reverse(views.checkout_submit), {'secret_word': word})
 
     def email_address_is_rejected(self, email_address):
-        response = self.client.post(
-            reverse(views.long_description_submit),
-            {'user_email': email_address})
+        response = self.client.post(reverse(views.long_description_submit), {'user_email': email_address})
         self.assertEqual(200, response.status_code)
 
     def test_do_git_description_mission_incorrectly(self):
-        self.assertFalse(
-            self.email_address_is_rejected('paulproteus@pathi.local'))
-        self.assertFalse(
-            self.email_address_is_rejected('filipovskii_off@Puppo.(none)'))
+        self.assertFalse(self.email_address_is_rejected('paulproteus@pathi.local'))
+        self.assertFalse(self.email_address_is_rejected('filipovskii_off@Puppo.(none)'))
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assertFalse(
-            view_helpers.mission_completed(paulproteus, 'git_config'))
+        self.assertFalse(view_helpers.mission_completed(paulproteus, 'git_config'))
 
     def test_do_git_description_mission_correctly(self):
         correct_email = 'paulproteus@openhatch.org'
-        self.client.post(reverse(views.long_description_submit),
-                         {'user_email': correct_email})
+        self.client.post(reverse(views.long_description_submit), {'user_email': correct_email})
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assertTrue(
-            view_helpers.mission_completed(paulproteus, 'git_config'))
+        self.assertTrue(view_helpers.mission_completed(paulproteus, 'git_config'))
 
-    def test_do_git_description_mission_correctly_with_weird_email_address(
-            self):
+    def test_do_git_description_mission_correctly_with_weird_email_address(self):
         correct_email = 'paulproteus@localhost.com'
-        self.client.post(reverse(views.long_description_submit),
-                         {'user_email': correct_email})
+        self.client.post(reverse(views.long_description_submit), {'user_email': correct_email})
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assertTrue(
-            view_helpers.mission_completed(paulproteus, 'git_config'))
+        self.assertTrue(view_helpers.mission_completed(paulproteus, 'git_config'))
 
     def test_do_rebase_mission_incorrectly(self):
         word = 'the wrong word'
         self.client.post(reverse(views.rebase_submit), {'secret_word': word})
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assertFalse(
-            view_helpers.mission_completed(paulproteus, 'git_rebase'))
+        self.assertFalse(view_helpers.mission_completed(paulproteus, 'git_rebase'))
 
     def test_do_diff_mission_correctly(self):
         self.client.post(reverse(views.resetrepo))
         cwd = self.repo_path
-        with open(os.path.join(cwd, '../../../missions/git/data/hello.patch'),
-                  'r') as expected_diff_file:
+        with open(os.path.join(cwd, '../../../missions/git/data/hello.patch'), 'r') as expected_diff_file:
             expected_diff = expected_diff_file.read()
         self.client.post(reverse(views.resetrepo))
         self.client.post(reverse(views.diff_submit), {'diff': expected_diff})
@@ -125,9 +107,7 @@ class GitViewTests(TwillTests):
     def test_do_diff_mission_correctly_in_swedish(self):
         self.client.post(reverse(views.resetrepo))
         cwd = self.repo_path
-        with open(
-            os.path.join(cwd, '../../../missions/git/data/swedish-patch'),
-                'r') as expected_diff_file:
+        with open(os.path.join(cwd, '../../../missions/git/data/swedish-patch'), 'r') as expected_diff_file:
             expected_diff = expected_diff_file.read()
         self.client.post(reverse(views.resetrepo))
         self.client.post(reverse(views.diff_submit), {'diff': expected_diff})
@@ -137,13 +117,10 @@ class GitViewTests(TwillTests):
     def test_do_diff_mission_incorrectly(self):
         self.client.post(reverse(views.resetrepo))
         cwd = self.repo_path
-        with open(os.path.join(cwd, '../../../missions/git/data/hello.patch'),
-                  'r') as expected_diff_file:
+        with open(os.path.join(cwd, '../../../missions/git/data/hello.patch'), 'r') as expected_diff_file:
             expected_diff = expected_diff_file.read()
         unexpected_diff = expected_diff.replace('Hello', 'Goodbye')
         self.client.post(reverse(views.resetrepo))
-        self.client.post(reverse(views.diff_submit),
-                         {'diff': unexpected_diff})
+        self.client.post(reverse(views.diff_submit), {'diff': unexpected_diff})
         paulproteus = Person.objects.get(user__username='paulproteus')
-        self.assertFalse(
-            view_helpers.mission_completed(paulproteus, 'git_diff'))
+        self.assertFalse(view_helpers.mission_completed(paulproteus, 'git_diff'))

--- a/mysite/missions/git/views.py
+++ b/mysite/missions/git/views.py
@@ -29,14 +29,10 @@ def resetrepo(request):
     if request.method != 'POST':
         return HttpResponseNotAllowed(['POST'])
     view_helpers.GitRepository(request.user.username).reset()
-    view_helpers.unset_mission_completed(
-        request.user.get_profile(), 'git_config')
-    view_helpers.unset_mission_completed(
-        request.user.get_profile(), 'git_checkout')
-    view_helpers.unset_mission_completed(
-        request.user.get_profile(), 'git_diff')
-    view_helpers.unset_mission_completed(
-        request.user.get_profile(), 'git_rebase')
+    view_helpers.unset_mission_completed(request.user.get_profile(), 'git_config')
+    view_helpers.unset_mission_completed(request.user.get_profile(), 'git_checkout')
+    view_helpers.unset_mission_completed(request.user.get_profile(), 'git_diff')
+    view_helpers.unset_mission_completed(request.user.get_profile(), 'git_rebase')
     if 'stay_on_this_page' in request.GET:
         return HttpResponseRedirect(reverse(main_page))
     else:
@@ -46,19 +42,15 @@ def resetrepo(request):
 @login_required
 def checkout_submit(request):
     # Initialize data array and some default values.
-    data = {}
-    data['git_checkout_form'] = forms.CheckoutForm()
-    data['git_checkout_error_message'] = ''
+    data = {'git_checkout_form': forms.CheckoutForm(), 'git_checkout_error_message': ''}
     if request.method == 'POST':
         form = forms.CheckoutForm(request.POST)
         if form.is_valid():
             if form.cleaned_data['secret_word'].lower() == 'the brain':
-                view_helpers.set_mission_completed(
-                    request.user.get_profile(), 'git_checkout')
+                view_helpers.set_mission_completed(request.user.get_profile(), 'git_checkout')
                 return HttpResponseRedirect(reverse(checkout))
             else:
-                data[
-                    'git_checkout_error_message'] = "The author's name is incorrect."
+                data['git_checkout_error_message'] = "The author's name is incorrect."
         data['git_checkout_form'] = form
     return checkout(request, data)
 
@@ -66,14 +58,11 @@ def checkout_submit(request):
 @login_required
 def long_description_submit(request):
     # Initialize data array and some default values.
-    data = {}
-    data['git_config_form'] = forms.ConfigForm()
-    data['git_config_error_message'] = ''
+    data = {'git_config_form': forms.ConfigForm(), 'git_config_error_message': ''}
     if request.method == 'POST':
         form = forms.ConfigForm(request.POST)
         if form.is_valid():
-            view_helpers.set_mission_completed(
-                request.user.get_profile(), 'git_config')
+            view_helpers.set_mission_completed(request.user.get_profile(), 'git_config')
             return HttpResponseRedirect(reverse(long_description))
 
     data['git_config_form'] = form
@@ -83,20 +72,15 @@ def long_description_submit(request):
 @login_required
 def diff_submit(request):
     # Initialize data array and some default values.
-    data = {}
-    data['git_diff_form'] = forms.DiffForm()
-    data['git_diff_error_message'] = ''
+    data = {'git_diff_form': forms.DiffForm(), 'git_diff_error_message': ''}
     if request.method == 'POST':
         form = forms.DiffForm(request.POST)
         if form.is_valid():
             if view_helpers.GitDiffMission.commit_if_ok(request.user.username, form.cleaned_data['diff']):
-                view_helpers.set_mission_completed(
-                    request.user.get_profile(), 'git_diff')
+                view_helpers.set_mission_completed(request.user.get_profile(), 'git_diff')
                 return HttpResponseRedirect(reverse(diff))
             else:
-                data[
-                    'git_diff_error_message'] = "Unable to commit the patch. Please check your patch and try again "
-
+                data['git_diff_error_message'] = "Unable to commit the patch. Please try again."
         else:
             return diff(request, {'git_diff_form': form})
         data['git_diff_form'] = form
@@ -106,30 +90,24 @@ def diff_submit(request):
 @login_required
 def rebase_submit(request):
     # Initialize data array and some default values.
-    data = {}
-    data['git_rebase_form'] = forms.RebaseForm()
-    data['git_rebase_error_message'] = ''
+    data = {'git_rebase_form': forms.RebaseForm(), 'git_rebase_error_message': ''}
     if request.method == 'POST':
         form = forms.RebaseForm(request.POST)
         if form.is_valid():
             lower_secret = form.cleaned_data['secret_word'].lower()
             if lower_secret == 'pinky' or lower_secret == 'pinky.':
-                view_helpers.set_mission_completed(
-                    request.user.get_profile(), 'git_rebase')
+                view_helpers.set_mission_completed(request.user.get_profile(), 'git_rebase')
                 return HttpResponseRedirect(reverse(rebase))
             else:
                 data['git_rebase_error_message'] = "The password is incorrect."
         data['git_rebase_form'] = form
     return rebase(request, data)
 
-# State manager
-
 
 class GitMissionPageState(MissionPageState):
-
+    """State manager"""
     def __init__(self, request, passed_data):
-        super(GitMissionPageState, self).__init__(
-            request, passed_data, 'Using Git')
+        super(GitMissionPageState, self).__init__(request, passed_data, 'Using Git')
 
     def as_dict_for_template_context(self):
         (data, person) = self.get_base_data_dict_and_person()
@@ -143,9 +121,7 @@ class GitMissionPageState(MissionPageState):
                 'git_rebase_done': view_helpers.mission_completed(person, 'git_rebase'),
             })
             if data['repository_exists']:
-                data.update({
-                    'checkout_url': repo.public_url,
-                })
+                data.update({'checkout_url': repo.public_url,})
         return data
 
 
@@ -166,7 +142,7 @@ def long_description(request, passed_data=None):
     data['git_config_form'] = forms.ConfigForm()
     if passed_data:
         data.update(passed_data)
-    return (request, 'missions/git/about_git.html', data)
+    return request, 'missions/git/about_git.html', data
 
 
 @login_required
@@ -177,7 +153,7 @@ def checkout(request, passed_data=None):
     state.mission_step_prerequisite = 'git_config'
     data = state.as_dict_for_template_context()
     data['git_checkout_form'] = forms.CheckoutForm()
-    return (request, 'missions/git/checkout.html', data)
+    return request, 'missions/git/checkout.html', data
 
 
 @login_required
@@ -190,7 +166,7 @@ def diff(request, passed_data=None):
     if 'git_diff_form' not in data:
         data['git_diff_form'] = forms.DiffForm()
     data['file_for_git_diff'] = 'hello.py'
-    return (request, 'missions/git/diff.html', data)
+    return request, 'missions/git/diff.html', data
 
 
 @login_required
@@ -201,7 +177,7 @@ def rebase(request, passed_data=None):
     state.mission_step_prerequisite = 'git_diff'
     data = state.as_dict_for_template_context()
     data['git_rebase_form'] = forms.RebaseForm()
-    return (request, 'missions/git/rebase.html', data)
+    return request, 'missions/git/rebase.html', data
 
 
 @view
@@ -209,4 +185,4 @@ def reference(request, passed_data=None):
     state = GitMissionPageState(request, passed_data)
     state.this_mission_page_short_name = 'Quick reference'
     data = state.as_dict_for_template_context()
-    return (request, 'missions/git/reference.html', data)
+    return request, 'missions/git/reference.html', data


### PR DESCRIPTION
In the spirit of [Raymond Hettinger's PyCon talk](http://www.pyvideo.org/video/3511/beyond-pep-8-best-practices-for-beautiful-inte), I'm relaxing the PEP8 line length to 90 or so characters. The length of test names and functions make it more difficult to understand the code flow when broken across multple lines vs kept as one long line.

As we try to increase coverage, cleanup tests, and work toward upgrading Django, these changes will help us be more efficient going forward. Once Django is at a more recent version, we can look at refactoring the long names if desired. I would love to see us move to Django 1.8 for security and maintainability. 