### PR TITLE
challenge feedback now visible in the top of the page

### DIFF
--- a/mysite/missions/templates/missions/shell/ls.html
+++ b/mysite/missions/templates/missions/shell/ls.html
@@ -20,6 +20,11 @@
     <div class='head'>
       <h3>Using ls for listing directory contents</h3>
     </div>
+    {% if command_ls_success %}
+        <div class="successmsg">
+          <p><strong>You have successfully completed this part of the mission.</strong></p>
+        </div>
+    {% endif %}
     <div class="body">
 
     <h3>ls: List directory contents</h3>
@@ -63,11 +68,6 @@
 
     <form method="post" action="{% url "mysite.missions.shell.views.command_ls_submit" %}#ls-form">{% csrf_token %}
         <div class="form-row">
-            {% if command_ls_success %}
-            <div class="successmsg">
-              <p><strong>You have successfully completed this part of the mission.</strong></p>
-            </div>
-            {% endif %}
             <input type="radio" name="option" value="1"> print the allocated size of each file, in blocks.<br>
             <input type="radio" name="option" value="2"> list subdirectories recursively.<br>
             <input type="radio" name="option" value="3"> reverse order while sorting.<br>


### PR DESCRIPTION
https://openhatch.org/missions/shell/ls
feedback block is moved at the top of the page.

#1749 

Demo:
http://imgur.com/yb8dMh0

If this also needs to be fixed for other pages, then please let me know.