### PR TITLE
many clarity and punctuation fixes; rewrote some sections for clarity

### DIFF
--- a/mysite/missions/templates/missions/diffpatch/hints.html
+++ b/mysite/missions/templates/missions/diffpatch/hints.html
@@ -37,22 +37,25 @@
   <br>
 
   <p>To work with patch, you can use:</p><br>
-  <b>patch [options] [originalfile [patchfile]]</b><br>
+      <kbd class="kbd">patch [options] [originalfile [patchfile]]</kbd><br>
   <p>but the more common method is:<br><br></p>
-  <b>patch -pnum &lt; patchfile.patch</b>
+      <kbd class="kbd">patch -pnum &lt; patchfile.patch</kbd>
 
   <p>-pnum is the option to tell patch how many levels of directories to ignore so
   it finds the correct files to patch.</p>
 
   <p>To work with diff, you can use:<br><br>
-  <b>diff -u original <em>updatedfile</em></b><br></p>
+      <kbd class="kbd">diff -u original <em>updatedfile</em></kbd><br></p>
 
-  <p>For Windows users, you can redirect the output of your diff to a new file
-  with this command:<br><br>
-  <b>diff -u original new > output.txt</b></p>
+      <p>For Windows users, you can redirect the output of your diff to a new file
+      with this command:<br><br>
+      <kbd class="kbd">diff -u original new &gt; output.txt</kbd></p>
 
-  <p><b>-u</b> is the Output NUM (default 3) lines of unified context.</p>
-  <p><b>-ur</b> is used when comparing directories of unified context by recursively comparing any subdirectories found.</p>
+      <p><kbd class="kbd">-u</kbd> is the number of lines of unified context to
+      output. You can specify a number by putting it after this option (e.g.
+      <kbd class="kbd">-u 12</kbd>). If no number is specified, it will use the
+      default of 3.</p>
+      <p><kbd class="kbd">-ur</kbd> is used when comparing directories of unified context by recursively comparing any subdirectories found.</p>
 
 
   <h3><b>Other resources</b></h3>

--- a/mysite/missions/templates/missions/diffpatch/hints.html
+++ b/mysite/missions/templates/missions/diffpatch/hints.html
@@ -24,52 +24,61 @@
     <h3>Quick reference</h3>
   </div>
     <div class="submodule-body body">
-    
-  <h3><b> Working with patch and diff</b></h3>
-  <p>When working with patch, you are dealing with a patchfile containing a difference listing produced by the <em>diff</em> program and applies those differences to               one or more original files, producing patched versions.</p>
-  
-  <p>When working with diff, it outputs the difference between two files, by comparing both files line by line.</p>
+
+  <h3><b>Working with patch and diff</b></h3>
+  <p>When working with patch, you are dealing with a patch file, which contains a
+  list of differences produced by the <em>diff</em> program. The patch file applies
+  those differences to one or more original files, producing patched versions.</p>
+
+  <p>In contrast, diff outputs the difference between two files by comparing both
+  files line by line.</p>
+
   <p>This page is just a quick reference; see the bottom for other resources.</p>
   <br>
-  
-  <p> To work with patch, you can use:<br><br>
- 	<b>patch [options] [originalfile [patchfile]]</b> <br><br> but the more common method is :<br><br>  <b>patch -pnum < patchfile.patch</p></b>
-  
-  <p> -pnum is the option to tell it how many levels of directories to ignore so it finds the correct files to patch.</p>
-  
-  <p> To work with diff, you can use:<br><br>
- 	<b>diff -u original <em>updatedfile</em></b><br></p>
- 	<p>For window users, redirect the output of your diff to a new file with this command:<br><br>
-	<b>diff -u original new > output.txt</b></p>
-	
-	<p> <b>-u</b> is the Output NUM (default 3) lines of unified context. </p>
-	<p> <b>-ur</b> is used when comparing directories of unified context by recursively comparing any subdirectories found.</p>
-  
-  
+
+  <p>To work with patch, you can use:</p><br>
+  <b>patch [options] [originalfile [patchfile]]</b><br>
+  <p>but the more common method is:<br><br></p>
+  <b>patch -pnum &lt; patchfile.patch</b>
+
+  <p>-pnum is the option to tell patch how many levels of directories to ignore so
+  it finds the correct files to patch.</p>
+
+  <p>To work with diff, you can use:<br><br>
+  <b>diff -u original <em>updatedfile</em></b><br></p>
+
+  <p>For Windows users, you can redirect the output of your diff to a new file
+  with this command:<br><br>
+  <b>diff -u original new > output.txt</b></p>
+
+  <p><b>-u</b> is the Output NUM (default 3) lines of unified context.</p>
+  <p><b>-ur</b> is used when comparing directories of unified context by recursively comparing any subdirectories found.</p>
+
+
   <h3><b>Other resources</b></h3>
   <br>
   <p>Patch is an efficent method to fix errors in text files. The following sites have further information about patch:</p>
   <ul class="raquo_bullets">
   <li><a href="http://en.wikipedia.org/wiki/Patch_(Unix)">Wikipedia has some good information about the <em>patch</em> function.</a></li>
-  <li>Patch comes with a user "manual". You can read that by typing <tt>man patch</tt> in a terminal, or by <a href="http://linux.die.net/man/1/patch">visiting this page</a>.</li>
+  <li>Patch comes with a user "manual." You can read it by typing <tt>man patch</tt> in a terminal, or by <a href="http://linux.die.net/man/1/patch">visiting this page</a>.</li>
   </ul>
-  
-  <p>There are different options to <em>diff</em>, which are detailed in diff's documentation.The followings sites are commonly used for further reading : </p>
-  
+
+  <p>There are many options for <em>diff</em>, which are detailed in diff's documentation. The following sites are good resources for further reading:</p>
+
   <ul class="raquo_bullets">
-      <li><a href="http://en.wikipedia.org/wiki/Diff_(Unix)">Wikipedia has some good information about the <em>diff</em> function.</a></li>
-      <li>Diff comes with a user "manual". You can read that by typing <tt>man diff</tt> in a terminal, or by <a href="http://linux.die.net/man/1/diff">visiting this page</a>.</li>
-      <br>
-      </ul> 
-   
+  <li><a href="http://en.wikipedia.org/wiki/Diff_(Unix)">Wikipedia has some good information about the <em>diff</em> function.</a></li>
+  <li>Diff also comes with a user manual. You can read it by typing <tt>man diff</tt> in a terminal, or by <a href="http://linux.die.net/man/1/diff">visiting this page</a>.</li>
+  <br>
+  </ul>
+
   <h3>Working with tarballs</h3>
 
   <ul class="raquo_bullets">
   <li><a href="http://openhatch.org/missions/tar/hints">Tools for working with tar archives.</a></li>
-  </ul> 
- </div>
+  </ul>
+    </div>
 
-{% endblock mission_main %} 
+{% endblock mission_main %}
 
 
 <!--

--- a/mysite/missions/templates/missions/git/checkout.html
+++ b/mysite/missions/templates/missions/git/checkout.html
@@ -32,7 +32,7 @@ You have to create your repository on the
 
 {% else %}
 
-<p>Your first mission is to obtain a copy of the remote git repository. For this mission, we will use the git repository you created in step one.  Running the following command will clone the remote repository and create a copy on your hard drive.</p>
+<p>Your first mission is to obtain a copy of the remote git repository. For this mission, we will use the git repository you created on the mission start page.  Running the following command will clone the remote repository and create a copy on your hard drive.</p>
 
 <p>You can clone the repository by running:<br style="clear: left;" />
 <code>git clone {{ checkout_url }} git_missions</code>

--- a/mysite/missions/templates/missions/shell/cd.html
+++ b/mysite/missions/templates/missions/shell/cd.html
@@ -65,7 +65,7 @@
     {% if command_cd_done %}
         <p class="next_mission_link">
         <a href='{% url "mysite.missions.shell.views.command_mkdir_rm" %}'>
-        On to next &raquo;</a></p>
+        On to the next one &raquo;</a></p>
     {% endif %}
 
     </div>

--- a/mysite/missions/templates/missions/shell/cd.html
+++ b/mysite/missions/templates/missions/shell/cd.html
@@ -42,7 +42,7 @@
     will move you to the Desktop subdirectory inside your home directory.</p>
 
     <h3>Challenge:</h3>
-    <p>Suppose your present working directory is <kbd class="kbd">/penguin/projects</kbd>,
+    <p>Suppose your current working directory is <kbd class="kbd">/penguin/projects</kbd>,
     what does the command <kbd class="kbd">cd</kbd> without a directory name do?</p>
     <form method="post" action="{% url "mysite.missions.shell.views.command_cd_submit" %}#cd-form">{% csrf_token %}
         <div class="form-row">

--- a/mysite/missions/templates/missions/shell/cp_mv.html
+++ b/mysite/missions/templates/missions/shell/cp_mv.html
@@ -22,40 +22,43 @@
     </div>
     <div class="body">
 
-    <h3>cp: copy files and directories:</h3>
-    <p>The <kbd class="kbd">cp</kbd> command will make a copy of a file for you. Example:</p>
+    <h3>cp: copy files and directories</h3>
+    <p>The <kbd class="kbd">cp</kbd> command will make a copy of a file for you. For example,</p>
 
     <code class="code">$ cp songs.txt music.txt</code>
 
     <p>will make an exact copy of <kbd class="kbd">songs.txt</kbd> and name it
-    <kbd class="kbd">music.txt</kbd>, but the file <kbd class="kbd">songs.txt</kbd>
-    will still be there.</p>
+    <kbd class="kbd">music.txt</kbd> (the file <kbd class="kbd">songs.txt</kbd>
+    will still be there, too).</p>
 
     <p>If you are copying a directory, you must use the option
-    <kbd class="kbd">-r (--recursive)</kbd> Example:</p>
+    <kbd class="kbd">-r (--recursive)</kbd>. For example,</p>
 
     <code class="code">$ cp -r songs music</code>
 
-    <p>Copies all the contents of <kbd class="kbd">songs</kbd> directory to
-    <kbd class="kbd">music</kbd> directory recursively. Remember? earlier we
-    explained how recursive option worked ? Here "recursively" means, to copy
-    the directory and all its files and subdirectories and all their files and
-    subdirectories of the subdirectories and all their files, and on and on,
-    "recursively".<br>
-    You can also use source and destination paths like:</p>
+    <p>copies all the contents of the <kbd class="kbd">songs</kbd> directory to the
+    <kbd class="kbd">music</kbd> directory recursively. Remember when we
+    explained how the recursive option worked when removing directories? Here,
+    "recursively" means we copy the directory and all its files and subdirectories,
+    and all the subdirectories' files and subdirectories, and on and on ("recursively")
+    until everything that was inside the <kbd class="kbd">songs</kbd> directory has
+    been copied to the <kbd class="kbd">music</kbd> directory.</p>
+
+    <p>You can also use source and destination paths:</p>
 
     <code class="code">$ cp <i>source-path</i> <i>destination-path</i></code>
 
-    <p>Example:</p>
+    <p>For example,</p>
 
     <code class="code">$ cp songs.txt music/list/</code>
 
-    <p>Will copy the file <kbd class="kbd">songs.txt</kbd> to a subdirectory
-    <kbd class="kbd">list</kbd> inside <kbd class="kbd">music</kbd> directory
-    which is in the present working directory</p>
-    <h3>mv: move (rename) files:</h3>
-    <p> The <kbd class="kbd">mv</kbd> command will move a file to a different
-    location or will rename a file. Examples are as follows:</p>
+    <p>will copy the file <kbd class="kbd">songs.txt</kbd> to a subdirectory
+    <kbd class="kbd">list</kbd> inside the <kbd class="kbd">music</kbd> directory
+    (which is in the current working directory).</p>
+
+    <h3>mv: move (rename) files</h3>
+    <p>The <kbd class="kbd">mv</kbd> command will rename a file or move a file to a
+    different location. Examples are as follows:</p>
 
     <code class="code">$ mv songs.txt music.txt</code>
 
@@ -101,7 +104,7 @@
     {% if command_cp_mv_done %}
         <p class="next_mission_link">
         <a href='{% url "mysite.missions.shell.views.more_info" %}'>
-        On to next &raquo;</a></p>
+        On to the next one &raquo;</a></p>
     {% endif %}
 
     </div>

--- a/mysite/missions/templates/missions/shell/ls.html
+++ b/mysite/missions/templates/missions/shell/ls.html
@@ -29,16 +29,16 @@
 
     <p><kbd class="kbd">ls</kbd> command with no option will list files and
     directories in bare format and you won't be able to view details like file
-    types, size, modification date, permission etc.</p>
+    type, size, modification date, permissions etc.</p>
 
     <p><b>2. List files using <kbd class="kbd">-l</kbd> option:</b></p>
 
     <code class="code">$ ls -l</code>
 
-    <p><kbd class="kbd">ls</kbd> command with option <kbd class="kbd">-l</kbd> i.e.
-    <kbd class="kbd">ls -l</kbd> will list files and directories along with their
-    size, modified date and time, owner of the file and it's permission.
-    Something like:</p>
+    <p>The <kbd class="kbd">ls</kbd> command with option <kbd class="kbd">-l</kbd> (i.e.
+    <kbd class="kbd">ls -l</kbd>) will list files and directories along with their
+    size, modified date and time, owner of the file, and permissions.
+    It will look something like this:</p>
     <pre>
     <kbd class="kbd">drwxr-xr-x   2 root root  4096 Oct 11 00:20 bin</kbd>
     </pre>
@@ -47,9 +47,9 @@
 
     <code class="code">$ ls -a</code>
 
-    <p><kbd class="kbd">ls</kbd> command with option <kbd class="kbd">-a</kbd>
-    i.e. <kbd class="kbd">ls -a</kbd> will list all the files including hidden
-    files starting with '.' (hidden file's name starts with '.')</p>
+    <p>The <kbd class="kbd">ls</kbd> command with option <kbd class="kbd">-a</kbd>
+    (i.e. <kbd class="kbd">ls -a</kbd>) will list all files, including hidden
+    files (whose names start with '.').</p>
 
     <p>There are many other options available. For more options, type
     <kbd class="kbd">ls --help</kbd> in your shell and you'll get a list of
@@ -82,7 +82,7 @@
     {% if command_ls_done %}
         <p class="next_mission_link">
             <a href='{% url "mysite.missions.shell.views.command_cd" %}'>
-        On to next &raquo;</a></p>
+        On to the next one &raquo;</a></p>
     {% endif %}
 
     </div>

--- a/mysite/missions/templates/missions/shell/mkdir_rm.html
+++ b/mysite/missions/templates/missions/shell/mkdir_rm.html
@@ -22,39 +22,43 @@
     </div>
     <div class="body">
 
-    <h3>mkdir: Make directory:</h3>
-    <p> The mkdir command will allow you to create directories. Example:</p>
+    <h3>mkdir: Make directory</h3>
+    <p> The mkdir command will allow you to create directories. For example,</p>
     <code class="code">$ mkdir penguin</code>
-    <p>will create a directory called "penguin".<br>
-    Any number of directories can be created simultaneously.
+    <p>will create a directory called "penguin".</p>
+
+    <p>Any number of directories can be created simultaneously.
     Thus, for example, the following command would create three directories
     within the current directory (i.e., the directory in which the user is
     currently working) with the names dir1, dir2 and dir3:</p>
     <code class="code">$ mkdir dir1 dir2 dir3</code>
-    <p>mkdir will return a warning message such as <kbd class="kbd">mkdir: cannot
-        create directory 'dir1': File exists</kbd> and will not create a file
+    <p>If a directory with that name already exists in the current directory,
+    mkdir will return a warning message such as <kbd class="kbd">mkdir: cannot
+    create directory 'dir1': File exists</kbd> and will not create a file
     with that name. However, it will then continue to create directories for any
     other names provided as arguments.</p>
 
     <h3>rm: Remove files or directories:</h3>
-    <p>The command name "rm" is derived from "remove". You can use this command
-    to remove or delete a file in your directory. For example, to remove
-    <kbd class="kbd">test.txt</kbd> present in your current directory, you will
-    have to type</p>
+    <p>The command name "rm" is derived from "remove." You can use this command
+    to remove or delete a file in your directory. For example, to remove a file named
+    <kbd class="kbd">test.txt</kbd> present in your current directory, you can
+    type</p>
     <code class="code">$ rm test.txt</code>
 
     <h3>Removing directories:</h3>
-    <p>By default <kbd class="kbd">rm</kbd> does not remove directories. If the
-    <kbd class="kbd">-r (--recursive)</kbd> option is specified, Example:</p>
+    <p>By default, <kbd class="kbd">rm</kbd> does not remove directories. If the
+    <kbd class="kbd">-r (--recursive)</kbd> option is specified, however, it will. For
+    example,</p>
     <code class="code">rm -r penguin</code>
     <p>will remove the directory <kbd class="kbd">penguin</kbd> and its contents
-    recursively. To understand what "recursively" means, think of it this way: to
-    remove the directory and all its files and subdirectories and all their files
-    and subdirectories of the subdirectories and all their files, and on and on, "recursively".
+    recursively. What does "recursively" mean? Think of it this way: this command will
+    remove the directory and all its files and subdirectories, and all the subdirectories'
+    files and subdirectories, and on and on ("recursively") until the original directory
+    <kbd class="kbd">penguin</kbd> is completely empty.
     </p>
 
     <h3>Challenge:</h3>
-    <p>What is the output of <kbd class="kbd">ls</kbd> command in the sequence given below ?</p>
+    <p>What is the output of the <kbd class="kbd">ls</kbd> command in the sequence given below?</p>
     <code class="snippet">
     $ ls<br>
     test.txt music<br>
@@ -86,7 +90,7 @@
     {% if command_mkdir_rm_done %}
         <p class="next_mission_link">
         <a href='{% url "mysite.missions.shell.views.command_cp_mv" %}'>
-        On to next &raquo;</a></p>
+        On to the next one &raquo;</a></p>
     {% endif %}
 
 

--- a/mysite/missions/templates/missions/shell/resources.html
+++ b/mysite/missions/templates/missions/shell/resources.html
@@ -23,8 +23,8 @@
     <div class="body">
 
     <h3>Other resources</h3>
-    <p>We introduced you with few of the most frequently used commands in the
-    shell. However, this is not it. There are many other ways to play with the
+    <p>We introduced you to a few of the most frequently used commands in the
+    shell. However, this is not it! There are many other ways to play with the
     shell, lots of commands and a number of command line utilities you can try.
     Given below are few external resources which you may find useful:</p>
 
@@ -41,7 +41,7 @@
     - Effective use of command line for beginners.</p>
 
     <p><a href="http://www.yolinux.com/TUTORIALS/LinuxTextEditors.html">
-    http://www.yolinux.com/TUTORIALS/LinuxTextEditors.html</a> - Know about text editors.</p>
+    http://www.yolinux.com/TUTORIALS/LinuxTextEditors.html</a> - Learn about text editors.</p>
     <p></p>
 
     <p class="next_mission_link">

--- a/mysite/missions/templates/missions/shell/structure.html
+++ b/mysite/missions/templates/missions/shell/structure.html
@@ -22,8 +22,8 @@
         <h3>File vs Directory</h3>
     </div>
     <div class="body">
-        <p>Before learning about shell commands you should know about files
-        and directories</p>
+        <p>Before learning about shell commands, you should know about files
+        and directories.</p>
 
         <h3>File:</h3>
         <p>A file is a collection of data that is stored on disk and that can be
@@ -41,8 +41,8 @@
         at the base of the directory tree hierarchy; it is the trunk from which
         all other files or directories branch.</p>
 
-        <p>Visit <a href="http://www.linuxnix.com/2012/07/abslute-path-vs-relative-path-in-linuxunix.html">here</a>
-        to know about what are paths and what is the difference between absolute and relative paths</p>
+        <p>Click <a href="http://www.linuxnix.com/2012/07/abslute-path-vs-relative-path-in-linuxunix.html">here</a>
+        to learn about paths and the difference between absolute and relative paths.</p>
 
       <p class="next_mission_link">
       <a href='{% url "mysite.missions.shell.views.command_ls" %}'>Get started with the shell &raquo;</a></p>


### PR DESCRIPTION
Resolves https://github.com/openhatch/oh-mainline/issues/1754

"Present working directory" strikes me as pretty close to "print working
directory," which is only addressed in windows-setup in the missions. As
such, it seems perhaps clearer to just skip that terminology for now.

It may be better to use the `kbd` or `<kbd class="kbd">` style in some sections
where that's currently not the case; some sections do interesting stuff when
viewed in an editor with syntax highlighting (e.g. swapping formatting).
Still true with the e.g. `patch -pnum < patchfile.patch` line, since the less-than
caret can get flagged as half a `<tag>`.

Would be just as happy to swap all the bolded code/bash lines
out for `kbd` formatted stuff instead — there's more opportunity for it here
(though I'm not sure of the precise extent), and there's an unusual (for the
missions) usage of `<tt>` in one file (and just that file).