### PR TITLE
convert django-http-proxy's Django migrations to South migrations

### DIFF
--- a/vendor/packages/django-http-proxy/httpproxy/migrations/0001_initial.py
+++ b/vendor/packages/django-http-proxy/httpproxy/migrations/0001_initial.py
@@ -1,67 +1,92 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
 
-from django.db import models, migrations
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Request'
+        db.create_table(u'httpproxy_request', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('method', self.gf('django.db.models.fields.CharField')(max_length=20)),
+            ('domain', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('port', self.gf('django.db.models.fields.PositiveSmallIntegerField')(default=80)),
+            ('path', self.gf('django.db.models.fields.CharField')(max_length=250)),
+            ('date', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+            ('querykey', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal(u'httpproxy', ['Request'])
+
+        # Adding unique constraint on 'Request', fields ['method', 'domain', 'port', 'path', 'querykey']
+        db.create_unique(u'httpproxy_request', ['method', 'domain', 'port', 'path', 'querykey'])
+
+        # Adding model 'RequestParameter'
+        db.create_table(u'httpproxy_requestparameter', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('request', self.gf('django.db.models.fields.related.ForeignKey')(related_name='parameters', to=orm['httpproxy.Request'])),
+            ('type', self.gf('django.db.models.fields.CharField')(default='G', max_length=1)),
+            ('order', self.gf('django.db.models.fields.PositiveSmallIntegerField')(default=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('value', self.gf('django.db.models.fields.CharField')(max_length=250, null=True, blank=True)),
+        ))
+        db.send_create_signal(u'httpproxy', ['RequestParameter'])
+
+        # Adding model 'Response'
+        db.create_table(u'httpproxy_response', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('request', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['httpproxy.Request'], unique=True)),
+            ('status', self.gf('django.db.models.fields.PositiveSmallIntegerField')(default=200)),
+            ('content_type', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('content', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal(u'httpproxy', ['Response'])
 
 
-class Migration(migrations.Migration):
+    def backwards(self, orm):
+        # Removing unique constraint on 'Request', fields ['method', 'domain', 'port', 'path', 'querykey']
+        db.delete_unique(u'httpproxy_request', ['method', 'domain', 'port', 'path', 'querykey'])
 
-    dependencies = [
-    ]
+        # Deleting model 'Request'
+        db.delete_table(u'httpproxy_request')
 
-    operations = [
-        migrations.CreateModel(
-            name='Request',
-            fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('method', models.CharField(max_length=20, verbose_name='method')),
-                ('domain', models.CharField(max_length=100, verbose_name='domain')),
-                ('port', models.PositiveSmallIntegerField(default=80)),
-                ('path', models.CharField(max_length=250, verbose_name='path')),
-                ('date', models.DateTimeField(auto_now=True)),
-                ('querykey', models.CharField(verbose_name='query key', max_length=255, editable=False)),
-            ],
-            options={
-                'get_latest_by': 'date',
-                'verbose_name': 'request',
-                'verbose_name_plural': 'requests',
-            },
-            bases=(models.Model,),
-        ),
-        migrations.CreateModel(
-            name='RequestParameter',
-            fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('type', models.CharField(default=b'G', max_length=1, choices=[(b'G', b'GET'), (b'P', b'POST')])),
-                ('order', models.PositiveSmallIntegerField(default=1)),
-                ('name', models.CharField(max_length=100, verbose_name='naam')),
-                ('value', models.CharField(max_length=250, null=True, verbose_name='value', blank=True)),
-                ('request', models.ForeignKey(related_name='parameters', verbose_name='request', to='httpproxy.Request')),
-            ],
-            options={
-                'ordering': ('order',),
-                'verbose_name': 'request parameter',
-                'verbose_name_plural': 'request parameters',
-            },
-            bases=(models.Model,),
-        ),
-        migrations.CreateModel(
-            name='Response',
-            fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('status', models.PositiveSmallIntegerField(default=200)),
-                ('content_type', models.CharField(max_length=200, verbose_name='inhoudstype')),
-                ('content', models.TextField(verbose_name='inhoud')),
-                ('request', models.OneToOneField(verbose_name='request', to='httpproxy.Request')),
-            ],
-            options={
-                'verbose_name': 'response',
-                'verbose_name_plural': 'responses',
-            },
-            bases=(models.Model,),
-        ),
-        migrations.AlterUniqueTogether(
-            name='request',
-            unique_together=set([('method', 'domain', 'port', 'path', 'querykey')]),
-        ),
-    ]
+        # Deleting model 'RequestParameter'
+        db.delete_table(u'httpproxy_requestparameter')
+
+        # Deleting model 'Response'
+        db.delete_table(u'httpproxy_response')
+
+
+    models = {
+        u'httpproxy.request': {
+            'Meta': {'unique_together': "(('method', 'domain', 'port', 'path', 'querykey'),)", 'object_name': 'Request'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '250'}),
+            'port': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '80'}),
+            'querykey': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'httpproxy.requestparameter': {
+            'Meta': {'ordering': "('order',)", 'object_name': 'RequestParameter'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'request': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'parameters'", 'to': u"orm['httpproxy.Request']"}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'G'", 'max_length': '1'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'})
+        },
+        u'httpproxy.response': {
+            'Meta': {'object_name': 'Response'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'request': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['httpproxy.Request']", 'unique': 'True'}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '200'})
+        }
+    }
+
+    complete_apps = ['httpproxy']


### PR DESCRIPTION
This was causing problem in migrations because Django's inbuilt migrations ( which was introduced in 1.7 ) was being used. 

Running
```
./manage.py schemamigration httpproxy --initial
```

converted them back to South migrations. 

#1734 